### PR TITLE
Fixed translations and unit tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+__pycache__/
 */*.mo
 /data/
 conf/config

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -22,6 +22,7 @@ local publishImage() = {
     name: "publish-image",
     kind: "pipeline",
     type: "docker",
+	trigger: {branch: ["mprweb"]},
     depends_on: ["run-tests"],
     volumes: [
         {

--- a/.drone/scripts/run-tests.sh
+++ b/.drone/scripts/run-tests.sh
@@ -22,7 +22,7 @@ until : > /dev/tcp/127.0.0.1/3306; do sleep 1s; done
 make -C po all install
 make -C test clean
 make -C test sh
-pytest
+docker/scripts/run-pytests.sh --no-coverage
 make -C test coverage
 
 flake8 --count aurweb

--- a/.drone/scripts/run-tests.sh
+++ b/.drone/scripts/run-tests.sh
@@ -21,7 +21,7 @@ until : > /dev/tcp/127.0.0.1/3306; do sleep 1s; done
 
 make -C po all install
 make -C test clean
-#make -C test sh
+make -C test sh
 
 # Set up config file to work properly for unit tests.
 sed -i 's|^user =.*|user = root|' conf/config.defaults

--- a/.drone/scripts/run-tests.sh
+++ b/.drone/scripts/run-tests.sh
@@ -22,6 +22,10 @@ until : > /dev/tcp/127.0.0.1/3306; do sleep 1s; done
 make -C po all install
 make -C test clean
 #make -C test sh
+
+# Config parser isn't using the username value set in 'run-pytests.sh', so we're gonna set it manually here before continuing.
+sed -i 's|*user =.*|user = root|' conf/config.defaults
+
 PROMETHEUS_MULTIPROC_DIR='/tmp_prometheus' docker/scripts/run-pytests.sh --no-coverage
 make -C test coverage
 

--- a/.drone/scripts/run-tests.sh
+++ b/.drone/scripts/run-tests.sh
@@ -22,7 +22,7 @@ until : > /dev/tcp/127.0.0.1/3306; do sleep 1s; done
 make -C po all install
 make -C test clean
 make -C test sh
-docker/scripts/run-pytests.sh --no-coverage
+PROMETHEUS_MULTIPROC_DIR='/tmp_prometheus' docker/scripts/run-pytests.sh --no-coverage
 make -C test coverage
 
 flake8 --count aurweb

--- a/.drone/scripts/run-tests.sh
+++ b/.drone/scripts/run-tests.sh
@@ -24,7 +24,7 @@ make -C test clean
 #make -C test sh
 
 # Config parser isn't using the username value set in 'run-pytests.sh', so we're gonna set it manually here before continuing.
-sed -i 's|*user =.*|user = root|' conf/config.defaults
+sed -i 's|^user =.*|user = root|' conf/config.defaults
 
 PROMETHEUS_MULTIPROC_DIR='/tmp_prometheus' docker/scripts/run-pytests.sh --no-coverage
 make -C test coverage

--- a/.drone/scripts/run-tests.sh
+++ b/.drone/scripts/run-tests.sh
@@ -21,7 +21,7 @@ until : > /dev/tcp/127.0.0.1/3306; do sleep 1s; done
 
 make -C po all install
 make -C test clean
-make -C test sh
+#make -C test sh
 PROMETHEUS_MULTIPROC_DIR='/tmp_prometheus' docker/scripts/run-pytests.sh --no-coverage
 make -C test coverage
 

--- a/.drone/scripts/run-tests.sh
+++ b/.drone/scripts/run-tests.sh
@@ -23,8 +23,10 @@ make -C po all install
 make -C test clean
 #make -C test sh
 
-# Config parser isn't using the username value set in 'run-pytests.sh', so we're gonna set it manually here before continuing.
+# Set up config file to work properly for unit tests.
 sed -i 's|^user =.*|user = root|' conf/config.defaults
+sed -i 's|^notify-cmd =.*|;&|' conf/config.defaults
+sed -i 's|^sendmail = .*|sendmail = YOUR_AUR_ROOT/util/sendmail|' conf/config.defaults
 
 PROMETHEUS_MULTIPROC_DIR='/tmp_prometheus' docker/scripts/run-pytests.sh --no-coverage
 make -C test coverage

--- a/.drone/scripts/run-tests.sh
+++ b/.drone/scripts/run-tests.sh
@@ -26,7 +26,7 @@ make -C test clean
 # Set up config file to work properly for unit tests.
 sed -i 's|^user =.*|user = root|' conf/config.defaults
 sed -i 's|^notify-cmd =.*|;&|' conf/config.defaults
-sed -i 's|^sendmail = .*|sendmail = YOUR_AUR_ROOT/util/sendmail|' conf/config.defaults
+sed -i 's|^sendmail =.*|sendmail = YOUR_AUR_ROOT/util/sendmail|' conf/config.defaults
 
 PROMETHEUS_MULTIPROC_DIR='/tmp_prometheus' docker/scripts/run-pytests.sh --no-coverage
 make -C test coverage

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ po/*.po~
 po/POTFILES
 schema/aur-schema-sqlite.sql
 test/test-results/
-test/trash directory*
+test/trash_directory*
 web/locale/*/
 web/html/*.gz
 

--- a/aurweb/scripts/notify.py
+++ b/aurweb/scripts/notify.py
@@ -78,7 +78,7 @@ class Notification:
             msg['To'] = to
             if self.get_cc():
                 msg['Cc'] = str.join(', ', self.get_cc())
-            msg['X-AUR-Reason'] = reason
+            msg['X-MPR-Reason'] = reason
             msg['Date'] = email.utils.formatdate(localtime=True)
 
             for key, value in self.get_headers().items():
@@ -138,7 +138,7 @@ class ResetKeyNotification(Notification):
             return [(self._to, self._lang)]
 
     def get_subject(self, lang):
-        return aurweb.l10n.translator.translate('AUR Password Reset', lang)
+        return aurweb.l10n.translator.translate('MPR Password Reset', lang)
 
     def get_body(self, lang):
         return aurweb.l10n.translator.translate(
@@ -155,12 +155,12 @@ class ResetKeyNotification(Notification):
 class WelcomeNotification(ResetKeyNotification):
     def get_subject(self, lang):
         return aurweb.l10n.translator.translate(
-            'Welcome to the Arch User Repository',
+            'Welcome to the makedeb Package Repository',
             lang)
 
     def get_body(self, lang):
         return aurweb.l10n.translator.translate(
-            'Welcome to the Arch User Repository! In order to set an '
+            'Welcome to the makedeb Package Repository! In order to set an '
             'initial password for your new account, please click the '
             'link [1] below. If the link does not work, try copying and '
             'pasting it into your browser.', lang)
@@ -189,7 +189,7 @@ class CommentNotification(Notification):
 
     def get_subject(self, lang):
         return aurweb.l10n.translator.translate(
-            'AUR Comment for {pkgbase}',
+            'MPR Comment for {pkgbase}',
             lang).format(pkgbase=self._pkgbase)
 
     def get_body(self, lang):
@@ -236,7 +236,7 @@ class UpdateNotification(Notification):
 
     def get_subject(self, lang):
         return aurweb.l10n.translator.translate(
-            'AUR Package Update: {pkgbase}',
+            'MPR Package Update: {pkgbase}',
             lang).format(pkgbase=self._pkgbase)
 
     def get_body(self, lang):
@@ -287,7 +287,7 @@ class FlagNotification(Notification):
 
     def get_subject(self, lang):
         return aurweb.l10n.translator.translate(
-            'AUR Out-of-date Notification for {pkgbase}',
+            'MPR Out-of-date Notification for {pkgbase}',
             lang).format(pkgbase=self._pkgbase)
 
     def get_body(self, lang):
@@ -327,7 +327,7 @@ class OwnershipEventNotification(Notification):
 
     def get_subject(self, lang):
         return aurweb.l10n.translator.translate(
-            'AUR Ownership Notification for {pkgbase}',
+            'MPR Ownership Notification for {pkgbase}',
             lang).format(pkgbase=self._pkgbase)
 
     def get_refs(self):
@@ -363,7 +363,7 @@ class ComaintainershipEventNotification(Notification):
 
     def get_subject(self, lang):
         return aurweb.l10n.translator.translate(
-            'AUR Co-Maintainer Notification for {pkgbase}',
+            'MPR Co-Maintainer Notification for {pkgbase}',
             lang).format(pkgbase=self._pkgbase)
 
     def get_refs(self):
@@ -408,7 +408,7 @@ class DeleteNotification(Notification):
 
     def get_subject(self, lang):
         return aurweb.l10n.translator.translate(
-            'AUR Package deleted: {pkgbase}',
+            'MPR Package deleted: {pkgbase}',
             lang).format(pkgbase=self._old_pkgbase)
 
     def get_body(self, lang):
@@ -545,7 +545,7 @@ class RequestCloseNotification(Notification):
             body = 'Request #%d has been %s by %s [1]' % \
                    (self._reqid, self._reason, self._user)
         else:
-            body = 'Request #%d has been %s automatically by the Arch User ' \
+            body = 'Request #%d has been %s automatically by the makedeb Package ' \
                    'Repository package request system' % \
                    (self._reqid, self._reason)
         if self._text.strip() == '':

--- a/aurweb/scripts/notify.py
+++ b/aurweb/scripts/notify.py
@@ -211,7 +211,7 @@ class CommentNotification(Notification):
 
     def get_headers(self):
         thread_id = '<pkg-notifications-' + self._pkgbase + \
-                    '@aur.archlinux.org>'
+                    '@mpr.hunterwittenborn.com>'
         return headers_reply(thread_id)
 
 
@@ -258,7 +258,7 @@ class UpdateNotification(Notification):
 
     def get_headers(self):
         thread_id = '<pkg-notifications-' + self._pkgbase + \
-                    '@aur.archlinux.org>'
+                    '@mpr.hunterwittenborn.com>'
         return headers_reply(thread_id)
 
 
@@ -492,7 +492,7 @@ class RequestOpenNotification(Notification):
         return refs
 
     def get_headers(self):
-        thread_id = '<pkg-request-' + str(self._reqid) + '@aur.archlinux.org>'
+        thread_id = '<pkg-request-' + str(self._reqid) + '@mpr.hunterwittenborn.com>'
         # Use a deterministic Message-ID for the first email referencing a
         # request.
         headers = headers_msgid(thread_id)
@@ -561,7 +561,7 @@ class RequestCloseNotification(Notification):
             return ()
 
     def get_headers(self):
-        thread_id = '<pkg-request-' + str(self._reqid) + '@aur.archlinux.org>'
+        thread_id = '<pkg-request-' + str(self._reqid) + '@mpr.hunterwittenborn.com>'
         headers = headers_reply(thread_id)
         return headers
 

--- a/conf/config.defaults
+++ b/conf/config.defaults
@@ -37,7 +37,7 @@ snapshot_uri = /cgit/aur.git/snapshot/%s.tar.gz
 enable-maintenance = 0
 maintenance-exceptions = 127.0.0.1
 render-comment-cmd = /usr/bin/aurweb-rendercomment
-localedir = YOUR_AUR_ROOT/aurweb/web/locale/
+localedir = YOUR_AUR_ROOT/web/locale/
 ; memcache, apc, or redis
 ; memcache/apc are supported in PHP, redis is supported in Python.
 cache = none

--- a/conf/config.defaults
+++ b/conf/config.defaults
@@ -19,13 +19,13 @@ login_timeout = 7200
 persistent_cookie_timeout = 2592000
 max_filesize_uncompressed = 8388608
 disable_http_login = 0
-aur_location = https://aur.archlinux.org
-git_clone_uri_anon = https://aur.archlinux.org/%s.git
-git_clone_uri_priv = ssh://aur@aur.archlinux.org/%s.git
+aur_location = https://mpr.hunterwittenborn.com
+git_clone_uri_anon = https://mpr.hunterwittenborn.com/%s.git
+git_clone_uri_priv = ssh://mpr@mpr.hunterwittenborn.com/%s.git
 max_rpc_results = 5000
 max_search_results = 2500
 max_depends = 1000
-aur_request_ml = aur-requests@lists.archlinux.org
+aur_request_ml = mpr-requests@lists.hunterwittenborn.com
 request_idle_time = 1209600
 request_archive_time = 15552000
 auto_orphan_age = 15552000
@@ -64,8 +64,8 @@ smtp-use-ssl = 0
 smtp-use-starttls = 0
 smtp-user =
 smtp-password =
-sender = notify@aur.archlinux.org
-reply-to = noreply@aur.archlinux.org
+sender = mpr@hunterwittenborn.com
+reply-to = mpr@hunterwittenborn.com
 
 [fingerprints]
 Ed25519 = ssh_key
@@ -91,7 +91,7 @@ repo-path = YOUR_AUR_ROOT/aurweb/aur.git/
 repo-regex = [a-z0-9][a-z0-9.+_-]*$
 git-shell-cmd = /usr/bin/git-shell
 git-update-cmd = /usr/bin/aurweb-git-update
-ssh-cmdline = ssh aur@aur.archlinux.org
+ssh-cmdline = ssh mpr@mpr.hunterwittenborn.com
 
 [update]
 max-blob-size = 256000

--- a/conf/config.defaults
+++ b/conf/config.defaults
@@ -89,6 +89,7 @@ htmldir = YOUR_AUR_ROOT/web/html
 
 [fastapi]
 session_secret = secret
+bind_address = 127.0.0.1:8082
 
 [serve]
 repo-path = YOUR_AUR_ROOT/aurweb/aur.git/

--- a/conf/config.defaults
+++ b/conf/config.defaults
@@ -83,6 +83,10 @@ openid_configuration =
 client_id =
 client_secret =
 
+[php]
+bind_address = 127.0.0.1:8081
+htmldir = YOUR_AUR_ROOT/web/html
+
 [fastapi]
 session_secret = secret
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       test: "bash /docker/health/redis.sh"
       interval: 3s
     ports:
-      - "16379:6379"
+      - "127.0.0.1:16379:6379"
 
   mariadb:
     image: aurweb:latest
@@ -58,7 +58,7 @@ services:
     ports:
       # This will expose mariadbd on 127.0.0.1:13306 in the host.
       # Ex: `mysql -uaur -paur -h 127.0.0.1 -P 13306 aurweb`
-      - "13306:3306"
+      - "127.0.0.1:13306:3306"
     volumes:
       - mariadb_run:/var/run/mysqld # Bind socket in this volume.
       - mariadb_data:/var/lib/mysql
@@ -88,7 +88,7 @@ services:
     ports:
       # This will expose mariadbd on 127.0.0.1:13307 in the host.
       # Ex: `mysql -uaur -paur -h 127.0.0.1 -P 13306 aurweb`
-      - "13307:3306"
+      - "127.0.0.1:13307:3306"
     volumes:
       - mariadb_test_run:/var/run/mysqld # Bind socket in this volume.
     healthcheck:
@@ -104,7 +104,7 @@ services:
     entrypoint: /docker/git-entrypoint.sh
     command: /docker/scripts/run-sshd.sh
     ports:
-      - "2222:2222"
+      - "127.0.0.1:2222:2222"
     healthcheck:
       test: "bash /docker/health/sshd.sh"
       interval: 3s
@@ -141,7 +141,7 @@ services:
       git:
         condition: service_healthy
     ports:
-      - "13000:3000"
+      - "127.0.0.1:13000:3000"
     volumes:
       - git_data:/aurweb/aur.git
 
@@ -161,7 +161,7 @@ services:
       git:
         condition: service_healthy
     ports:
-      - "13001:3000"
+      - "127.0.0.1:13001:3000"
     volumes:
       - git_data:/aurweb/aur.git
 
@@ -205,7 +205,7 @@ services:
       - mariadb_run:/var/run/mysqld
       - archives:/var/lib/aurweb/archives
     ports:
-      - "19000:9000"
+      - "127.0.0.1:19000:9000"
 
   fastapi:
     image: aurweb:latest
@@ -234,7 +234,7 @@ services:
     volumes:
       - mariadb_run:/var/run/mysqld
     ports:
-      - "18000:8000"
+      - "127.0.0.1:18000:8000"
 
   nginx:
     image: aurweb:latest
@@ -244,8 +244,8 @@ services:
     entrypoint: /docker/nginx-entrypoint.sh
     command: /docker/scripts/run-nginx.sh
     ports:
-      - "8443:8443" # PHP
-      - "8444:8444" # FastAPI
+      - "127.0.0.1:8443:8443" # PHP
+      - "127.0.0.1:8444:8444" # FastAPI
     healthcheck:
       test: "bash /docker/health/nginx.sh"
       interval: 3s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,9 +247,6 @@ services:
     ports:
       - "127.0.0.1:8443:8443" # PHP
       - "127.0.0.1:8444:8444" # FastAPI
-    healthcheck:
-      test: "bash /docker/health/nginx.sh"
-      interval: 3s
     depends_on:
       - cgit-php
       - cgit-fastapi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -282,6 +282,8 @@ services:
     stdin_open: true
     tty: true
     volumes:
+      - ./conf/config.defaults:/aurweb/conf/config.defaults
+      - ./conf/config.dev:/aurweb/conf/config.dev
       - ./data/git_data:/aurweb/aur.git
       - ./cache:/data
       - ./aurweb:/aurweb/aurweb
@@ -308,6 +310,7 @@ services:
     depends_on:
       - mariadb_test
     volumes:
+      - ./docker:/docker
       - mariadb_test_run:/var/run/mysqld
       - ./conf/config.defaults:/aurweb/conf/config.defaults
       - ./conf/config.dev:/aurweb/conf/config.dev
@@ -337,6 +340,7 @@ services:
     depends_on:
       - mariadb_test
     volumes:
+      - ./docker:/docker
       - mariadb_test_run:/var/run/mysqld
       - ./conf/config.defaults:/aurweb/conf/config.defaults
       - ./conf/config.dev:/aurweb/conf/config.dev

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -30,6 +30,7 @@ cp "${CONFIG_FILE}" conf/config
 sed -i 's|^password =.*|;&|' conf/config
 sed -i 's|^user =.*|user = root|' conf/config
 sed -i 's|^port =.^|;&|' conf/config
+sed -i "s|YOUR_AUR_ROOT|$(pwd)|" conf/config
 
 # Run pytest with optional targets in front of it.
 pytest

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -25,6 +25,15 @@ done
 rm -rf $PROMETHEUS_MULTIPROC_DIR
 mkdir -p $PROMETHEUS_MULTIPROC_DIR
 
+# Set up config file.
+cp "${CONFIG_FILE}" conf/config
+sed -i 's|^password =.*|;&|' conf/config
+sed -i 's|^user =.*|user = root|' conf/config
+sed -i 's|^port =.^|;&|' conf/config
+
+cat conf/config
+exit 1
+
 # Run pytest with optional targets in front of it.
 pytest -vv
 

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -32,10 +32,7 @@ sed -i 's|^user =.*|user = root|' conf/config
 sed -i 's|^port =.^|;&|' conf/config
 sed -i "s|YOUR_AUR_ROOT|$(pwd)|" conf/config
 
-for i in $(find ./conf/ -type f); do
-	echo "=== ${i}"
-	cat "${i}"
-done
+cat -n conf/config
 
 # Run pytest with optional targets in front of it.
 pytest

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -32,9 +32,6 @@ sed -i 's|^user =.*|user = root|' conf/config
 sed -i 's|^port =.^|;&|' conf/config
 sed -i "s|YOUR_AUR_ROOT|$(pwd)|" conf/config
 
-cat conf/config
-exit 1
-
 # Run pytest with optional targets in front of it.
 pytest
 

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -32,6 +32,11 @@ sed -i 's|^user =.*|user = root|' conf/config
 sed -i 's|^port =.^|;&|' conf/config
 sed -i "s|YOUR_AUR_ROOT|$(pwd)|" conf/config
 
+for i in $(find ./conf/ -type f); do
+	echo "=== ${i}"
+	cat "${i}"
+done
+
 # Run pytest with optional targets in front of it.
 pytest
 

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -26,7 +26,7 @@ rm -rf $PROMETHEUS_MULTIPROC_DIR
 mkdir -p $PROMETHEUS_MULTIPROC_DIR
 
 # Run pytest with optional targets in front of it.
-pytest
+pytest -vv
 
 # By default, report coverage and move it into cache.
 if [ $COVERAGE -eq 1 ]; then

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -31,11 +31,8 @@ sed -i 's|^password =.*|;&|' conf/config
 sed -i 's|^user =.*|user = root|' conf/config
 sed -i 's|^port =.^|;&|' conf/config
 
-cat conf/config
-exit 1
-
 # Run pytest with optional targets in front of it.
-pytest -vv
+pytest
 
 # By default, report coverage and move it into cache.
 if [ $COVERAGE -eq 1 ]; then

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -32,6 +32,9 @@ sed -i 's|^user =.*|user = root|' conf/config
 sed -i 's|^port =.^|;&|' conf/config
 sed -i "s|YOUR_AUR_ROOT|$(pwd)|" conf/config
 
+cat conf/config
+exit 1
+
 # Run pytest with optional targets in front of it.
 pytest
 

--- a/docker/scripts/run-pytests.sh
+++ b/docker/scripts/run-pytests.sh
@@ -32,8 +32,6 @@ sed -i 's|^user =.*|user = root|' conf/config
 sed -i 's|^port =.^|;&|' conf/config
 sed -i "s|YOUR_AUR_ROOT|$(pwd)|" conf/config
 
-cat -n conf/config
-
 # Run pytest with optional targets in front of it.
 pytest
 

--- a/docker/scripts/run-tests.sh
+++ b/docker/scripts/run-tests.sh
@@ -2,11 +2,21 @@
 set -eou pipefail
 dir=$(dirname $0)
 
+
 # Clean up coverage and stuff.
 make -C test clean
 
+# Set up config file.
+cp "${CONFIG_FILE}" conf/config
+sed -i 's|^password =.*|;&|' conf/config
+sed -i 's|^user =.*|user = root|' conf/config
+sed -i 's|^port =.^|;&|' conf/config
+
 # Run sharness tests.
 bash $dir/run-sharness.sh
+
+# Pytest also sets up the config file, so we'll remove the one we set up.
+rm conf/config
 
 # Run Python tests with MariaDB database.
 # Pass --silence to avoid reporting coverage. We will do that below.

--- a/docker/scripts/run-tests.sh
+++ b/docker/scripts/run-tests.sh
@@ -11,6 +11,7 @@ cp "${CONFIG_FILE}" conf/config
 sed -i 's|^password =.*|;&|' conf/config
 sed -i 's|^user =.*|user = root|' conf/config
 sed -i 's|^port =.^|;&|' conf/config
+sed -i "s|YOUR_AUR_ROOT|$(pwd)|" conf/config
 
 # Run sharness tests.
 bash $dir/run-sharness.sh

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # safa1996alfulaij <safa1996alfulaij@gmail.com>, 2015
@@ -199,7 +199,7 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
 msgstr "مرحبًا بك في م‌م‌آ! فضلًا اقرأ %sإرشادات مستخدمي م‌م‌آ%s و%sإرشادات مستخدمي م‌م‌آ الموثوقين (م‌م)%s لمعلومات أكثر."
 
@@ -224,7 +224,7 @@ msgstr "إخلاء مسؤوليّة"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
 msgstr "حزم م‌م‌آ هي حزم قدّمها المستخدمين. أيّ استخدام للملفّات يكون على مسؤوليّتك الخاصّة."
 
@@ -263,7 +263,7 @@ msgstr "طلب الحذف"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr "اطلب أن تُزال الحزمة من مستودع مستخدمي آرتش. فضلًا لا تستخدم هذه إن كانت الحزمة معطوبة ويمكن إصلاحها بسهولة. بدل ذلك تواصل مع مصين الحزمة وأبلغ عن طلب \"يتيمة\" إن تطلّب الأمر."
@@ -292,13 +292,13 @@ msgstr "تقديم الحزم"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr "غِت Git عبر SSH يُستخدم الآن لتقديم الحزم إلى مستودع مستخدمي آرتش (م‌م‌آ). طالع قسم %sتقديم الحزم%s في صفحة مستودع مستخدمي آرتش في ويكي آرتش لتفاصيل أكثر."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
 msgstr "بصمات SSH الآتية مستخدمة في م‌م‌آ:"
 
 #: html/home.php
@@ -308,9 +308,9 @@ msgstr "النّقاش"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
 msgstr "النّقاشات العاّمة حول مستودع مستخدمي آرتش (م‌م‌آ) وبنية المستخدمين الموثوقين تكون في  %saur-general%s. للنّقاشات المتعلّقة بتطوير واجهة وِبّ م‌م‌آ، استخدم قائمة %saur-dev%s البريديّة."
 
 #: html/home.php
@@ -320,8 +320,8 @@ msgstr "الإبلاغ عن العلل"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr "إن وجدت علّة في واجهة وِبّ م‌م‌آ، فضلًا املأ تقريرًا بها في %sمتعقّب العلل%s. استخدم المتعقّب للإبلاغ عن العلل في واجهة وِبّ م‌م‌آ %sفقط%s. للإبلاغ عن علل الحزم راسل مديرها أو اترك تعليقًا في صفحة الحزمة المناسبة."
@@ -498,7 +498,7 @@ msgstr "احذف الحزمة"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
+"from the MPR: "
 msgstr "استخدم هذه الاستمارة لحذف أساس الحزمة %s%s%s والحزم الآتية من م‌م‌آ:"
 
 #: html/pkgdel.php
@@ -1133,7 +1133,7 @@ msgstr "ُأُغلق الطّلب بنجاح."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr "يمكنك استخدام هذه الاستمارة لحذف حساب م‌م‌آ هذا %s نهائيًّا."
 
 #: template/account_delete.php
@@ -1294,7 +1294,7 @@ msgstr "أخفِ عنوان البريد الإلكترونيّ"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1343,7 +1343,7 @@ msgstr "أعد كتابة كلمة المرور"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "المعلومات الآتية مطلوبة فقط إن أردت تقديم حزم إلى مستودع مستخدمي آرتش."
 
 #: template/account_edit_form.php
@@ -1376,7 +1376,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1599,7 +1599,7 @@ msgstr "أضف تعليقًا"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2134,7 +2134,7 @@ msgid "Back"
 msgstr "السّابق"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2146,19 +2146,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2175,7 +2175,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2185,7 +2185,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2195,7 +2195,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2210,7 +2210,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2225,7 +2225,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/ast.po
+++ b/po/ast.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # enolp <enolp@softastur.org>, 2014-2015,2017
@@ -200,7 +200,7 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
 msgstr ""
 
@@ -225,7 +225,7 @@ msgstr ""
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr ""
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr ""
@@ -293,13 +293,13 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr ""
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
 msgstr ""
 
 #: html/home.php
@@ -309,9 +309,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
 msgstr ""
 
 #: html/home.php
@@ -321,8 +321,8 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -499,7 +499,7 @@ msgstr ""
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
+"from the MPR: "
 msgstr ""
 
 #: html/pkgdel.php
@@ -1134,7 +1134,7 @@ msgstr ""
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr ""
 
 #: template/account_delete.php
@@ -1295,7 +1295,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1344,7 +1344,7 @@ msgstr ""
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr ""
 
 #: template/account_edit_form.php
@@ -1377,7 +1377,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2115,7 +2115,7 @@ msgid "Back"
 msgstr ""
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2127,19 +2127,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2156,7 +2156,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2166,7 +2166,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2176,7 +2176,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2191,7 +2191,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2206,7 +2206,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Adolfo Jayme-Barrientos, 2014
@@ -200,9 +200,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Benvingut a l'AUR! Si us plau, llegiu les %sdirectrius d'usuari d'AUR%s i les %sdirectrius de TU (usuari de confiança) d'AUR%s per més informació."
+msgstr "Benvingut a l'MPR! Si us plau, llegiu les %sdirectrius d'usuari d'MPR%s i les %sdirectrius de TU (usuari de confiança) d'MPR%s per més informació."
 
 #: html/home.php
 #, php-format
@@ -225,7 +225,7 @@ msgstr "Avís legal"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr ""
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr ""
@@ -293,13 +293,13 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr ""
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
 msgstr ""
 
 #: html/home.php
@@ -309,9 +309,9 @@ msgstr "Discussió"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
 msgstr ""
 
 #: html/home.php
@@ -321,8 +321,8 @@ msgstr "Comunicar errada"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -499,7 +499,7 @@ msgstr "Esborrar el paquet"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
+"from the MPR: "
 msgstr ""
 
 #: html/pkgdel.php
@@ -1134,7 +1134,7 @@ msgstr ""
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr ""
 
 #: template/account_delete.php
@@ -1295,7 +1295,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1344,7 +1344,7 @@ msgstr "Escriu altre cop la contrasenya"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr ""
 
 #: template/account_edit_form.php
@@ -1377,7 +1377,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr "Afegir un comentari"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2115,7 +2115,7 @@ msgid "Back"
 msgstr "Enrere"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2127,19 +2127,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2156,7 +2156,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2166,7 +2166,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2176,7 +2176,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2191,7 +2191,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2206,7 +2206,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Daniel Milde <daniel@milde.cz>, 2017
@@ -203,7 +203,7 @@ msgstr "Hledat balíčky, které spolu-spravuji"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
 msgstr ""
 
@@ -228,9 +228,9 @@ msgstr ""
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Obsah balíčků AUR je vytvořen uživateli. Jakékoli použití poskytnutých souborů je na vlastní nebezpečí."
+msgstr "Obsah balíčků MPR je vytvořen uživateli. Jakékoli použití poskytnutých souborů je na vlastní nebezpečí."
 
 #: html/home.php
 msgid "Learn more..."
@@ -267,7 +267,7 @@ msgstr "Žádost o smazání"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr ""
@@ -296,14 +296,14 @@ msgstr "Odeslání balíčků"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr ""
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Pro AUR se používají následující otisky SSH"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Pro MPR se používají následující otisky SSH"
 
 #: html/home.php
 msgid "Discussion"
@@ -312,9 +312,9 @@ msgstr "Diskuze"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
 msgstr ""
 
 #: html/home.php
@@ -324,8 +324,8 @@ msgstr "Hlášení chyb"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -502,7 +502,7 @@ msgstr "Smazat balíček"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
+"from the MPR: "
 msgstr ""
 
 #: html/pkgdel.php
@@ -1137,8 +1137,8 @@ msgstr "Žádost byla úspěšně uzavřena."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Tento formulář můžete použít k trvalému odstranění účtu AUR %s."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Tento formulář můžete použít k trvalému odstranění účtu MPR %s."
 
 #: template/account_delete.php
 #, php-format
@@ -1298,7 +1298,7 @@ msgstr "Skrýt email"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1347,8 +1347,8 @@ msgstr "Heslo znovu"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "Následující informace jsou požadovány pouze v případě, že chcete odeslat balíčky do Arch User Repository."
+" the makedeb Package Repository."
+msgstr "Následující informace jsou požadovány pouze v případě, že chcete odeslat balíčky do makedeb Package Repository."
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1380,7 +1380,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1601,7 +1601,7 @@ msgstr "Přidat komentář"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2128,7 +2128,7 @@ msgid "Back"
 msgstr "Zpět"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2140,19 +2140,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2169,7 +2169,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2179,7 +2179,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2189,7 +2189,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2204,7 +2204,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2219,7 +2219,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/da.po
+++ b/po/da.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Linuxbruger <y.z@live.dk>, 2018
@@ -200,9 +200,9 @@ msgstr "Søg efter pakker jeg co-vedligeholder"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Velkommen til AUR! Venligst læs %sAUR Bruger Retningslinier %s og %sAUR TU Retningslinier%s for mere information."
+msgstr "Velkommen til MPR! Venligst læs %sMPR Bruger Retningslinier %s og %sMPR TU Retningslinier%s for mere information."
 
 #: html/home.php
 #, php-format
@@ -225,9 +225,9 @@ msgstr "ANSVARSFRASKRIVELSE"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "AUR pakker er bruger produceret materiale. Hvilken som helst brug af de filer der er stillet til rådighed er på din egen risiko."
+msgstr "MPR pakker er bruger produceret materiale. Hvilken som helst brug af de filer der er stillet til rådighed er på din egen risiko."
 
 #: html/home.php
 msgid "Learn more..."
@@ -264,7 +264,7 @@ msgstr "Sletning Forespørgsel"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr ""
@@ -293,13 +293,13 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr ""
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
 msgstr ""
 
 #: html/home.php
@@ -309,9 +309,9 @@ msgstr "Diskussion"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
 msgstr ""
 
 #: html/home.php
@@ -321,8 +321,8 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -499,7 +499,7 @@ msgstr "Slet pakke"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
+"from the MPR: "
 msgstr ""
 
 #: html/pkgdel.php
@@ -1134,7 +1134,7 @@ msgstr ""
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr ""
 
 #: template/account_delete.php
@@ -1295,7 +1295,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1344,7 +1344,7 @@ msgstr "Bekræft adgangskode"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr ""
 
 #: template/account_edit_form.php
@@ -1377,7 +1377,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr "Tilføj kommentar"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2115,7 +2115,7 @@ msgid "Back"
 msgstr "Tilbage"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2127,19 +2127,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2156,7 +2156,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2166,7 +2166,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2176,7 +2176,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2191,7 +2191,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2206,7 +2206,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/de.po
+++ b/po/de.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # 9d91e189c22376bb4ee81489bc27fc28, 2013
@@ -216,9 +216,9 @@ msgstr "Suche nach Paketen die ich mitbetreue"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Willkommen im AUR! Für weitere Informationen lies bitte die %sAUR User Guidelines%s und die %sAUR TU Guidelines%s."
+msgstr "Willkommen im MPR! Für weitere Informationen lies bitte die %sMPR User Guidelines%s und die %sMPR TU Guidelines%s."
 
 #: html/home.php
 #, php-format
@@ -241,9 +241,9 @@ msgstr "DISCLAIMER: Offiziell nicht unterstützte PKGBUILDS werden von den Benut
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "AUR Pakete sind von Benutzern erstellter Inhalt. Die Benutzung der angebotenen Dateien erfolgt auf eigenes Risiko."
+msgstr "MPR Pakete sind von Benutzern erstellter Inhalt. Die Benutzung der angebotenen Dateien erfolgt auf eigenes Risiko."
 
 #: html/home.php
 msgid "Learn more..."
@@ -280,10 +280,10 @@ msgstr "Löschanfrage"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Anfrage zum Entfernen eines Pakets aus dem Arch User Repository. Bitte benutze diese nicht, wenn das Paket kaputt ist und leich repariert werden kann. Sondern kontaktiere den Maintainer und reiche eine Verwaisungsanfrage ein, wenn nötig."
+msgstr "Anfrage zum Entfernen eines Pakets aus dem makedeb Package Repository. Bitte benutze diese nicht, wenn das Paket kaputt ist und leich repariert werden kann. Sondern kontaktiere den Maintainer und reiche eine Verwaisungsanfrage ein, wenn nötig."
 
 #: html/home.php
 msgid "Merge Request"
@@ -309,14 +309,14 @@ msgstr "Pakete einreichen"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Git über SSH wird jetzt benutzt um Pakete in das AUR einzureichen. Siehe die %sEinreichen von Paketen%s Sektion von der Arch User Repository ArchWiki Seite für mehr Details."
+msgstr "Git über SSH wird jetzt benutzt um Pakete in das MPR einzureichen. Siehe die %sEinreichen von Paketen%s Sektion von der makedeb Package Repository ArchWiki Seite für mehr Details."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Die folgenden SSH Fingerabdrücke werden für das AUR benutzt:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Die folgenden SSH Fingerabdrücke werden für das MPR benutzt:"
 
 #: html/home.php
 msgid "Discussion"
@@ -325,10 +325,10 @@ msgstr "Diskussion"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Grundsätzliche Diskussionen bezüglich des Arch User Repository (AUR) und vertrauenswürdigen Benutzern finden auf %saur-general%s statt. Für Diskussionen im Bezug auf die Entwicklung des AUR Web-Interface benutze die %saur-dev%s Mailingliste."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Grundsätzliche Diskussionen bezüglich des makedeb Package Repository (MPR) und vertrauenswürdigen Benutzern finden auf %saur-general%s statt. Für Diskussionen im Bezug auf die Entwicklung des MPR Web-Interface benutze die %saur-dev%s Mailingliste."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -337,11 +337,11 @@ msgstr "Fehler melden"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Wenn du einen Fehler im AUR Web-Interface findest, fülle bitte eine Fehler-Meldung in unserem %sbug-tracker%s aus. Benutze den Tracker %snur%s, um Fehler im AUR zu melden. Für falsch gepackte Pakete, wende dich bitte direkt an den zuständigen Maintainer, oder hinterlasse einen Kommentar auf der entsprechenden Seite des Pakets."
+msgstr "Wenn du einen Fehler im MPR Web-Interface findest, fülle bitte eine Fehler-Meldung in unserem %sbug-tracker%s aus. Benutze den Tracker %snur%s, um Fehler im MPR zu melden. Für falsch gepackte Pakete, wende dich bitte direkt an den zuständigen Maintainer, oder hinterlasse einen Kommentar auf der entsprechenden Seite des Pakets."
 
 #: html/home.php
 msgid "Package Search"
@@ -515,8 +515,8 @@ msgstr "Paket löschen"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Benutze dieses Formular um die Paketbasis %s%s%s und die folgenden Pakete vom AUR zu löschen:"
+"from the MPR: "
+msgstr "Benutze dieses Formular um die Paketbasis %s%s%s und die folgenden Pakete vom MPR zu löschen:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1150,8 +1150,8 @@ msgstr "Anfrage erfolgreich geschlossen."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Du kannst dieses Formular verwenden, um den AUR Account unwiderruflich zu entfernen %s."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Du kannst dieses Formular verwenden, um den MPR Account unwiderruflich zu entfernen %s."
 
 #: template/account_delete.php
 #, php-format
@@ -1311,7 +1311,7 @@ msgstr "Verstecke E-Mail-Adresse"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1360,8 +1360,8 @@ msgstr "Bestätige das Passwort"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "Die folgende Information wird nur benötigt, wenn du Pakete beim Arch User Repository einreichen willst."
+" the makedeb Package Repository."
+msgstr "Die folgende Information wird nur benötigt, wenn du Pakete beim makedeb Package Repository einreichen willst."
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1393,7 +1393,7 @@ msgstr "Dein aktuelles Passwort"
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr "Kommentar hinzufügen"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2131,8 +2131,8 @@ msgid "Back"
 msgstr "Zurück"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "AUR Passwort-Reset"
+msgid "MPR Password Reset"
+msgstr "MPR Passwort-Reset"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2143,20 +2143,20 @@ msgid ""
 msgstr "Eine Passwort-Reset wurde für den Account {user}, der mit dieser E-Mail-Adresse verknüpft ist, angefordert. Wenn Du Dein Passwort zurücksetzen möchtest, folge dem untenstehenden Link [1], ansonsten kannst Du diese Nachricht ignorieren und nichts wird geschehen."
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
-msgstr "Willkommen im Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
+msgstr "Willkommen im makedeb Package Repository"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
-msgstr "Willkommen im Arch User Repository! Um ein Passwort für dein neues Konto festzulegen, klicke bitte auf den unten stehenden Link [1]. Sollte das nicht funktionieren, versuche den Link zu kopieren und in deinem Browser einzufügen."
+msgstr "Willkommen im makedeb Package Repository! Um ein Passwort für dein neues Konto festzulegen, klicke bitte auf den unten stehenden Link [1]. Sollte das nicht funktionieren, versuche den Link zu kopieren und in deinem Browser einzufügen."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "AUR Kommentar für {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "MPR Kommentar für {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2172,8 +2172,8 @@ msgstr "Wenn Du keine weiteren Benachrichtigungen für dieses Paket erhalten wil
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "AUR Paket-Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "MPR Paket-Update: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2182,8 +2182,8 @@ msgstr "{user} [1] hat einen neuen Commit in {pkgbase} [2] gepushed."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "AUR Out-of-date Benachrichtigung für {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "MPR Out-of-date Benachrichtigung für {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2192,8 +2192,8 @@ msgstr "Dein Paket {pkgbase} [1] wurde von {user} [2] als veraltet markiert:"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "AUR Besitzer Benachrichtigung für {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "MPR Besitzer Benachrichtigung für {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2207,8 +2207,8 @@ msgstr "Das Paket {pkgbase} [1] wurde von {user} [2] verstoßen."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "AUR Co-Maintainer Benachrichtigung für {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "MPR Co-Maintainer Benachrichtigung für {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2222,8 +2222,8 @@ msgstr "Du wurdest von der liste der Co-Maintainer für {pkgbase} [1] entfernt."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "AUR Paket gelöscht: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "MPR Paket gelöscht: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/el.po
+++ b/po/el.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Achilleas Pipinellis, 2014
@@ -204,9 +204,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Καλωσήρθατε στο AUR! Διαβάστε παρακαλώ τον %sOδηγό Χρηστών του AUR%s και τον %sΟδηγό των Trusted Users%s για περισσότερες πληροφορίες. "
+msgstr "Καλωσήρθατε στο MPR! Διαβάστε παρακαλώ τον %sOδηγό Χρηστών του MPR%s και τον %sΟδηγό των Trusted Users%s για περισσότερες πληροφορίες. "
 
 #: html/home.php
 #, php-format
@@ -229,7 +229,7 @@ msgstr "ΑΠΟΠΟΙΗΣΗ ΕΥΘΥΝΗΣ"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
 msgstr ""
 
@@ -268,7 +268,7 @@ msgstr ""
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr ""
@@ -297,13 +297,13 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr ""
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
 msgstr ""
 
 #: html/home.php
@@ -313,9 +313,9 @@ msgstr "Συζήτηση"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
 msgstr ""
 
 #: html/home.php
@@ -325,8 +325,8 @@ msgstr "Αναφορά Σφαλμάτων"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -503,7 +503,7 @@ msgstr "Διαγράψτε πακέτο"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
+"from the MPR: "
 msgstr ""
 
 #: html/pkgdel.php
@@ -1138,7 +1138,7 @@ msgstr ""
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr ""
 
 #: template/account_delete.php
@@ -1299,7 +1299,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1348,7 +1348,7 @@ msgstr "Πληκτρολογήστε ξανά τον κωδικό σας."
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr ""
 
 #: template/account_edit_form.php
@@ -1381,7 +1381,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1600,7 +1600,7 @@ msgstr "Προσθέστε σχόλιο"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2119,7 +2119,7 @@ msgid "Back"
 msgstr "Πίσω"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2131,19 +2131,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2160,7 +2160,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2170,7 +2170,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2180,7 +2180,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2195,7 +2195,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2210,7 +2210,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/es.po
+++ b/po/es.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Adolfo Jayme-Barrientos, 2015
@@ -209,9 +209,9 @@ msgstr "Buscar paquetes que soy coencargado"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "¡Bienvenido al repositorio de usuarios de Arch! Léase las %sDirectrices del usuario del AUR%s y las %sDirectrices del usuario de confianza del AUR%s para mayor información."
+msgstr "¡Bienvenido al repositorio de usuarios de Arch! Léase las %sDirectrices del usuario del MPR%s y las %sDirectrices del usuario de confianza del MPR%s para mayor información."
 
 #: html/home.php
 #, php-format
@@ -234,9 +234,9 @@ msgstr "ACLARATORIA"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Los paquetes del AUR son producidos por los usuarios. Cualquier uso de los archivos de estos es a tu propio riesgo."
+msgstr "Los paquetes del MPR son producidos por los usuarios. Cualquier uso de los archivos de estos es a tu propio riesgo."
 
 #: html/home.php
 msgid "Learn more..."
@@ -273,7 +273,7 @@ msgstr "Solicitud de eliminación"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr "Solicitar la eliminación de un paquete del repositorio de usuarios de Arch. No utilices esta opción si un paquete está roto pero puede ser arreglado fácilmente. En cambio, contacta al encargado del paquete y presenta una solicitud de orfandad si es necesario."
@@ -302,14 +302,14 @@ msgstr "Subir paquetes"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Ahora se utiliza Git sobre SSH para subir paquetes al AUR. Véase la sección %sSubir paquetes%s de la wiki del repositorio de usuarios de Arch para más detalles."
+msgstr "Ahora se utiliza Git sobre SSH para subir paquetes al MPR. Véase la sección %sSubir paquetes%s de la wiki del repositorio de usuarios de Arch para más detalles."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Las siguientes huellas SSH están en uso para el AUR."
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Las siguientes huellas SSH están en uso para el MPR."
 
 #: html/home.php
 msgid "Discussion"
@@ -318,10 +318,10 @@ msgstr "Debate"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "La discusión general sobre el repositorio de usuarios de Arch (AUR) y la estructura de usuarios de confianza se realiza en la lista de correos %saur-general%s. Para la discusión en relación con el desarrollo de la interfaz web del AUR, utiliza la lista de correo %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "La discusión general sobre el repositorio de usuarios de Arch (MPR) y la estructura de usuarios de confianza se realiza en la lista de correos %saur-general%s. Para la discusión en relación con el desarrollo de la interfaz web del MPR, utiliza la lista de correo %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -330,11 +330,11 @@ msgstr "Informe de errores"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Si encuentras un error en la interfaz web del AUR, llena un informe de error en nuestro %srastreador de errores o «bug tracker»%s. Usa este para reportar %súnicamente%s errores de la interfaz web del AUR. Para reportar errores de empaquetado debes contactar al encargado o dejar un comentario en la página respectiva del paquete."
+msgstr "Si encuentras un error en la interfaz web del MPR, llena un informe de error en nuestro %srastreador de errores o «bug tracker»%s. Usa este para reportar %súnicamente%s errores de la interfaz web del MPR. Para reportar errores de empaquetado debes contactar al encargado o dejar un comentario en la página respectiva del paquete."
 
 #: html/home.php
 msgid "Package Search"
@@ -508,8 +508,8 @@ msgstr "Eliminar paquete"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Usa este formulario para eliminar el paquete base %s%s%s y los siguientes paquetes en el AUR:"
+"from the MPR: "
+msgstr "Usa este formulario para eliminar el paquete base %s%s%s y los siguientes paquetes en el MPR:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -585,7 +585,7 @@ msgstr "Marcado como obsoleto"
 msgid ""
 "Use this form to flag the package base %s%s%s and the following packages "
 "out-of-date: "
-msgstr "Usa este formulario para marcar el paquete base %s%s%s y los siguientes paquetes en el AUR como obsoletos:"
+msgstr "Usa este formulario para marcar el paquete base %s%s%s y los siguientes paquetes en el MPR como obsoletos:"
 
 #: html/pkgflag.php
 #, php-format
@@ -1143,8 +1143,8 @@ msgstr "Solicitud cerrada exitosamente"
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Puedes usar este formulario para eliminar la cuenta de %s en AUR permanentemente."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Puedes usar este formulario para eliminar la cuenta de %s en MPR permanentemente."
 
 #: template/account_delete.php
 #, php-format
@@ -1304,7 +1304,7 @@ msgstr "Ocultar dirreción de correo"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1353,7 +1353,7 @@ msgstr "Reescribe la contraseña"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "La siguiente información únicamente es necesaria si deseas subir paquetes al repositorio de usuarios de Arch."
 
 #: template/account_edit_form.php
@@ -1386,7 +1386,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgstr "Regresar a detalles"
 #: template/footer.php
 #, php-format
 msgid "Copyright %s 2004-%d aurweb Development Team."
-msgstr "Derechos de autor %s 2004 - %d, equipo desarrollador de la web del AUR."
+msgstr "Derechos de autor %s 2004 - %d, equipo desarrollador de la web del MPR."
 
 #: template/header.php
 msgid " My Account"
@@ -1605,7 +1605,7 @@ msgstr "Añadir un comentario"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2124,8 +2124,8 @@ msgid "Back"
 msgstr "Atrás"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "Reiniciarlizar contraseña del AUR"
+msgid "MPR Password Reset"
+msgstr "Reiniciarlizar contraseña del MPR"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2136,20 +2136,20 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr "Bienvenido al repositorio de usuarios de Arch"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "Comentario en el AUR para {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "Comentario en el MPR para {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2165,7 +2165,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2175,7 +2175,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2185,7 +2185,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2200,7 +2200,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2215,7 +2215,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/es_419.po
+++ b/po/es_419.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Angel Velasquez <angvp@archlinux.org>, 2011
@@ -207,9 +207,9 @@ msgstr "Buscar paquetes que soy coencargado"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "¡Bienvenido al repositorio de usuarios de Arch! Lea la %sGuía del usuario del AUR%s y la %sGuía del usuario de Confianza del AUR%s para mayor información."
+msgstr "¡Bienvenido al repositorio de usuarios de Arch! Lea la %sGuía del usuario del MPR%s y la %sGuía del usuario de Confianza del MPR%s para mayor información."
 
 #: html/home.php
 #, php-format
@@ -232,9 +232,9 @@ msgstr "ACLARATORIA"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Los paquetes en el AUR son producidos por los usuarios. Cualquier uso de ellos o sus archivos es a su propio riesgo."
+msgstr "Los paquetes en el MPR son producidos por los usuarios. Cualquier uso de ellos o sus archivos es a su propio riesgo."
 
 #: html/home.php
 msgid "Learn more..."
@@ -271,7 +271,7 @@ msgstr "Petición de Borrado"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr "Pedir que un paquete sea borrado del Repositorio Usuarios de Arch. Por favor, no use esta opción si un paquete está roto y se puede arreglar fácilmente. En cambio, contacte con el encargado del paquete y presentar solicitud orfandad si es necesario."
@@ -300,14 +300,14 @@ msgstr "Subir paquetes"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Ahora se usa Git sobre SSH para subir paquetes al AUR. Véase la sección %sSubir paquetes%s de la wiki del Repositorio de Usuarios de Arch para más información."
+msgstr "Ahora se usa Git sobre SSH para subir paquetes al MPR. Véase la sección %sSubir paquetes%s de la wiki del Repositorio de Usuarios de Arch para más información."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Las siguientes huellas SSH están en uso para el AUR."
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Las siguientes huellas SSH están en uso para el MPR."
 
 #: html/home.php
 msgid "Discussion"
@@ -316,10 +316,10 @@ msgstr "Debate"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "La discusión general acerca del Repositorio de Usuarios de Arch (AUR) y la estructura de Usuarios de Confianza se realiza en la lista de correos %saur-general%s. Para discusiones relacionadas con el desarrollo de la interfaz web del AUR, utilice la lista de correo %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "La discusión general acerca del Repositorio de Usuarios de Arch (MPR) y la estructura de Usuarios de Confianza se realiza en la lista de correos %saur-general%s. Para discusiones relacionadas con el desarrollo de la interfaz web del MPR, utilice la lista de correo %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -328,11 +328,11 @@ msgstr "Informe de errores"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Si encuentra un error en la interfaz web del AUR, llene un informe de fallo en nuestro %s«bug tracker»%s. Use este para reportar %súnicamente%s errores de la interfaz web del AUR. Para reportar errores de empaquetado debe contactar con el encargado o dejar un comentario en la página respectiva del paquete."
+msgstr "Si encuentra un error en la interfaz web del MPR, llene un informe de fallo en nuestro %s«bug tracker»%s. Use este para reportar %súnicamente%s errores de la interfaz web del MPR. Para reportar errores de empaquetado debe contactar con el encargado o dejar un comentario en la página respectiva del paquete."
 
 #: html/home.php
 msgid "Package Search"
@@ -506,8 +506,8 @@ msgstr "Borrar paquete"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Use este formulario para borrar el paquete base %s%s%s y los siguientes paquetes en el AUR:"
+"from the MPR: "
+msgstr "Use este formulario para borrar el paquete base %s%s%s y los siguientes paquetes en el MPR:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -583,7 +583,7 @@ msgstr "Marcado como desactualizado"
 msgid ""
 "Use this form to flag the package base %s%s%s and the following packages "
 "out-of-date: "
-msgstr "Use este formulario para marcar el paquete base %s%s%s y los siguientes paquetes en el AUR como desactualizados:"
+msgstr "Use este formulario para marcar el paquete base %s%s%s y los siguientes paquetes en el MPR como desactualizados:"
 
 #: html/pkgflag.php
 #, php-format
@@ -1141,8 +1141,8 @@ msgstr "Petición cerrada exitosamente"
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Puede usar este formulario para borrar la cuenta de %s en AUR permanentemente."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Puede usar este formulario para borrar la cuenta de %s en MPR permanentemente."
 
 #: template/account_delete.php
 #, php-format
@@ -1302,7 +1302,7 @@ msgstr "Ocultar dirreción de correo"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1351,7 +1351,7 @@ msgstr "Reescriba la contraseña"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "La siguiente información es necesaria únicamente si quiere subir paquetes al Repositorio de Usuarios de Arch."
 
 #: template/account_edit_form.php
@@ -1384,7 +1384,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr "Regresar a detalles"
 #: template/footer.php
 #, php-format
 msgid "Copyright %s 2004-%d aurweb Development Team."
-msgstr "Derechos de autor %s 2004 - %d, equipo de desarrollo de la web del AUR."
+msgstr "Derechos de autor %s 2004 - %d, equipo de desarrollo de la web del MPR."
 
 #: template/header.php
 msgid " My Account"
@@ -1603,7 +1603,7 @@ msgstr "Agregar un comentario"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2122,8 +2122,8 @@ msgid "Back"
 msgstr "Atrás"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "Reiniciar contraseña del AUR"
+msgid "MPR Password Reset"
+msgstr "Reiniciar contraseña del MPR"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2134,20 +2134,20 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr "Bienvenido al repositorio de usuarios de Arch"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "Comentario en el AUR para el paquete base {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "Comentario en el MPR para el paquete base {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2163,7 +2163,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2173,7 +2173,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2183,7 +2183,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2198,7 +2198,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2213,7 +2213,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/fi.po
+++ b/po/fi.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Elias Autio, 2016
@@ -201,9 +201,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Tervetuloa AURiin! Luethan %sAURin käyttäjä ohjeen%s sekä %sTU-käyttäjän oppaan%s, kun tarvitset lisätietoa."
+msgstr "Tervetuloa MPRiin! Luethan %sMPRin käyttäjä ohjeen%s sekä %sTU-käyttäjän oppaan%s, kun tarvitset lisätietoa."
 
 #: html/home.php
 #, php-format
@@ -226,9 +226,9 @@ msgstr "Vastuuvapauslauseke"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "AUR-paketit ovat käyttäjien luomia eivätkä ole virallisesti tuettuja. Näiden käyttäminen on omalla vastuullasi."
+msgstr "MPR-paketit ovat käyttäjien luomia eivätkä ole virallisesti tuettuja. Näiden käyttäminen on omalla vastuullasi."
 
 #: html/home.php
 msgid "Learn more..."
@@ -265,10 +265,10 @@ msgstr "Poistopyyntö"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Hallintapyyntö paketin poistamiseksi AUR:ista. Jos paketti on jollain tapaa rikki tai huono, mutta helposti korjattavissa, tulisi ensisijaisesti olla yhteydessä paketin ylläpitäjään ja viimekädessä pistää paketin hylkäämispyyntö menemään."
+msgstr "Hallintapyyntö paketin poistamiseksi MPR:ista. Jos paketti on jollain tapaa rikki tai huono, mutta helposti korjattavissa, tulisi ensisijaisesti olla yhteydessä paketin ylläpitäjään ja viimekädessä pistää paketin hylkäämispyyntö menemään."
 
 #: html/home.php
 msgid "Merge Request"
@@ -294,14 +294,14 @@ msgstr "Paketien lisääminen ja päivittäminen"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Pakettien lisääminen ja päivittäminen uudessa AUR versiossa tapahtuu SSH-yhteyden yli Git-versionhallinan avulla. Tarkemman ohjeet löytyvät Arch Linuxin wiki-oppaan AUR-sivulta kohdasta %sPakettien lisääminen%s."
+msgstr "Pakettien lisääminen ja päivittäminen uudessa MPR versiossa tapahtuu SSH-yhteyden yli Git-versionhallinan avulla. Tarkemman ohjeet löytyvät Arch Linuxin wiki-oppaan MPR-sivulta kohdasta %sPakettien lisääminen%s."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "AUR käyttää seuraavia SSH-tunnisteita:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "MPR käyttää seuraavia SSH-tunnisteita:"
 
 #: html/home.php
 msgid "Discussion"
@@ -310,10 +310,10 @@ msgstr "Keskustelu"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Yleinen keskustelu AUR:iin ja Luotettuihin käyttäjiin liittyen käydään postitusluettelossa %saur-general%s. AUR-verkkokäyttöliittymän kehittämiseen liittyvä keskustelu käydään postitusluettelossa %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Yleinen keskustelu MPR:iin ja Luotettuihin käyttäjiin liittyen käydään postitusluettelossa %saur-general%s. MPR-verkkokäyttöliittymän kehittämiseen liittyvä keskustelu käydään postitusluettelossa %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -322,11 +322,11 @@ msgstr "Virheiden raportointi"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Jos löydät AUR-verkkokäyttöliittymästa virheen, täytä virheenilmoituslomake %svirheenseurannassamme%s. Käytä sivustoa %sainoastaan%s verkkokäyttöliittymän virheiden ilmoittamiseen. Ilmoittaaksesi pakettien virheistä, ota yhteys paketin ylläpitäjään tai jätä kommentti paketin sivulla."
+msgstr "Jos löydät MPR-verkkokäyttöliittymästa virheen, täytä virheenilmoituslomake %svirheenseurannassamme%s. Käytä sivustoa %sainoastaan%s verkkokäyttöliittymän virheiden ilmoittamiseen. Ilmoittaaksesi pakettien virheistä, ota yhteys paketin ylläpitäjään tai jätä kommentti paketin sivulla."
 
 #: html/home.php
 msgid "Package Search"
@@ -500,8 +500,8 @@ msgstr "Poista paketti"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Käytä tätä lomaketta poistaaksesi pakettikannan %s%s%s ja seuraavat paketit AUR:sta:"
+"from the MPR: "
+msgstr "Käytä tätä lomaketta poistaaksesi pakettikannan %s%s%s ja seuraavat paketit MPR:sta:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1135,7 +1135,7 @@ msgstr ""
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr ""
 
 #: template/account_delete.php
@@ -1296,7 +1296,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1345,7 +1345,7 @@ msgstr "Salasana uudelleen:"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr ""
 
 #: template/account_edit_form.php
@@ -1378,7 +1378,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr "Lisää kommentti"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2116,7 +2116,7 @@ msgid "Back"
 msgstr "Takaisin"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2128,19 +2128,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
-msgstr "Tervetuloa AURiin"
+msgid "Welcome to the makedeb Package Repository"
+msgstr "Tervetuloa MPRiin"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
-msgstr "Tervetuloa AUR:iin! Asettaaksesi ensimmäisen salasanan uudelle tilillesi, klikkaa alla olevaa linkkiä [1]. Jos linkki ei toimi, kokeile kopioida ja liittää se selaimeesi."
+msgstr "Tervetuloa MPR:iin! Asettaaksesi ensimmäisen salasanan uudelle tilillesi, klikkaa alla olevaa linkkiä [1]. Jos linkki ei toimi, kokeile kopioida ja liittää se selaimeesi."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2157,7 +2157,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2167,8 +2167,8 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "AUR: Ilmoitus paketin {pkgbase} vanhentumisesta"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "MPR: Ilmoitus paketin {pkgbase} vanhentumisesta"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2177,7 +2177,7 @@ msgstr "Pakettisi {pkgbase} [1] on merkitty vanhentuneeksi. Merkinnän teki käy
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2192,7 +2192,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2207,7 +2207,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Alexandre Macabies <web+transifex@zopieux.com>, 2018
@@ -206,9 +206,9 @@ msgstr "Rechercher les paquets que je co-maintiens"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Bienvenue sur AUR ! Veuillez lire les %sconsignes pour les utilisateurs d’AUR%s et les %sconsignes pour les utilisateurs de confiance%s pour plus d’information."
+msgstr "Bienvenue sur MPR ! Veuillez lire les %sconsignes pour les utilisateurs d’MPR%s et les %sconsignes pour les utilisateurs de confiance%s pour plus d’information."
 
 #: html/home.php
 #, php-format
@@ -231,9 +231,9 @@ msgstr "AVERTISSEMENT"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Les paquets AUR sont produits par des utilisateurs. Toute utilisation des fichiers fournis se fait à vos propres risques."
+msgstr "Les paquets MPR sont produits par des utilisateurs. Toute utilisation des fichiers fournis se fait à vos propres risques."
 
 #: html/home.php
 msgid "Learn more..."
@@ -270,10 +270,10 @@ msgstr "Requête de suppression"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Demande qu'un paquet soit supprimé d'AUR. Prière de ne pas l'utiliser si un paquet est cassé et que le problème peut être réglé facilement. À la place, contactez le mainteneur du paquet, et soumettez une requête de destitution si nécessaire."
+msgstr "Demande qu'un paquet soit supprimé d'MPR. Prière de ne pas l'utiliser si un paquet est cassé et que le problème peut être réglé facilement. À la place, contactez le mainteneur du paquet, et soumettez une requête de destitution si nécessaire."
 
 #: html/home.php
 msgid "Merge Request"
@@ -299,14 +299,14 @@ msgstr "Soumission de paquets"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Git par-dessus SSH est maintenant utilisé pour soumettre des paquets sur AUR. Voir la section %sSoumettre des paquets%s sur la page Arch User Repository du wiki pour plus de détails."
+msgstr "Git par-dessus SSH est maintenant utilisé pour soumettre des paquets sur MPR. Voir la section %sSoumettre des paquets%s sur la page makedeb Package Repository du wiki pour plus de détails."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Les empreintes SSH suivantes sont utilisées pour AUR :"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Les empreintes SSH suivantes sont utilisées pour MPR :"
 
 #: html/home.php
 msgid "Discussion"
@@ -315,10 +315,10 @@ msgstr "Discussion"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Les discussions générales en rapport avec AUR (Arch User Repository, dépôt des utilisateurs d’Arch Linux) et les TU (Trusted User, utilisateurs de confiance) ont lieu sur %saur-general%s. Pour les discussions en rapport avec le développement de l'interface web d'AUR, utilisez la mailing-list %saur-dev.%s"
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Les discussions générales en rapport avec MPR (makedeb Package Repository, dépôt des utilisateurs d’Arch Linux) et les TU (Trusted User, utilisateurs de confiance) ont lieu sur %saur-general%s. Pour les discussions en rapport avec le développement de l'interface web d'MPR, utilisez la mailing-list %saur-dev.%s"
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -327,11 +327,11 @@ msgstr "Rapports de bug"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Si vous trouvez un bug dans l'interface web d'AUR, merci de remplir un rapport de bug sur le %sbug tracker%s. N’utilisez le tracker %sque%s pour les bugs de  l'interface web d'AUR. Pour signaler un bug dans un paquet, contactez directement le mainteneur du paquet, ou laissez un commentaire sur la page du paquet."
+msgstr "Si vous trouvez un bug dans l'interface web d'MPR, merci de remplir un rapport de bug sur le %sbug tracker%s. N’utilisez le tracker %sque%s pour les bugs de  l'interface web d'MPR. Pour signaler un bug dans un paquet, contactez directement le mainteneur du paquet, ou laissez un commentaire sur la page du paquet."
 
 #: html/home.php
 msgid "Package Search"
@@ -505,8 +505,8 @@ msgstr "Supprimer le paquet"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Utilisez ce formulaire pour supprimer le paquet de base %s%s%s et les paquets suivants de AUR :"
+"from the MPR: "
+msgstr "Utilisez ce formulaire pour supprimer le paquet de base %s%s%s et les paquets suivants de MPR :"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1140,8 +1140,8 @@ msgstr "Requête fermée avec succès."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Vous ne pouvez pas utiliser ce formulaire pour effacer le compte AUR %s de façon permanente."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Vous ne pouvez pas utiliser ce formulaire pour effacer le compte MPR %s de façon permanente."
 
 #: template/account_delete.php
 #, php-format
@@ -1301,7 +1301,7 @@ msgstr "Cacher l'adresse e-mail"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1350,8 +1350,8 @@ msgstr "Retapez le mot de passe"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "L'information suivante est requise uniquement si vous voulez soumettre des paquets sur AUR"
+" the makedeb Package Repository."
+msgstr "L'information suivante est requise uniquement si vous voulez soumettre des paquets sur MPR"
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1383,7 +1383,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1602,7 +1602,7 @@ msgstr "Ajouter un commentaire"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2121,8 +2121,8 @@ msgid "Back"
 msgstr "Retour"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "Réinitialisation de mot de passe AUR"
+msgid "MPR Password Reset"
+msgstr "Réinitialisation de mot de passe MPR"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2133,20 +2133,20 @@ msgid ""
 msgstr "Une demande de réinitialisation de mot de passe a été présentée pour le compte {user} associé à votre adresse e-mail. Si vous souhaitez réinitialiser votre mot de passe suivez le lien [1] ci-dessous, sinon ignorez ce message et rien ne se passera."
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr "Bienvenue sur le dépôt des utilisateurs d'Arch Linux"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr "Bienvenue sur le dépôt des utilisateurs d'Arch Linux ! Afin de générer un mot de passe pour votre nouveau compte, veuillez suivre le lien [1] ci-dessous. Si le lien ne fonctionne pas, copiez-le et collez-le dans votre navigateur web. "
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "Commentaires AUR pour {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "Commentaires MPR pour {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2162,8 +2162,8 @@ msgstr "Si vous ne souhaitez plus recevoir de notifications à propos de ce paqu
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "Paquet AUR mis à jour : {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "Paquet MPR mis à jour : {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2172,8 +2172,8 @@ msgstr "{user} [1] a poussé un nouveau commit vers {pkgbase} [2]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "Notification de paquet AUR périmé pour {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "Notification de paquet MPR périmé pour {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2182,8 +2182,8 @@ msgstr "Votre paquet {pkgbase} [1] a été marqué comme périmé par {user} [2]
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "Notification de paquet AUR adopté pour {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "Notification de paquet MPR adopté pour {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2197,8 +2197,8 @@ msgstr "Le paquet {pkgbase} [1] a été destitué par {user} [2]. "
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "Notification de paquet AUR co-maintenu pour {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "Notification de paquet MPR co-maintenu pour {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2212,8 +2212,8 @@ msgstr "Vous avez été retiré de la liste des co-mainteneurs de {pkgbase} [1].
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "Paquet AUR supprimé : {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "Paquet MPR supprimé : {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/he.po
+++ b/po/he.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # GenghisKhan <genghiskhan@gmx.ca>, 2016
@@ -200,9 +200,9 @@ msgstr "חיפוש אחר חבילה שאני מתחזק המשנה שלה"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "ברוך בואך ל־AUR, מאגר תרומות המשתמשים של ארץ׳! נא לקרוא את %sהכללים למשתמש ב־AUR%s ואת %sהכללים למשתמשים מהימנים ב־AUR%s."
+msgstr "ברוך בואך ל־MPR, מאגר תרומות המשתמשים של ארץ׳! נא לקרוא את %sהכללים למשתמש ב־MPR%s ואת %sהכללים למשתמשים מהימנים ב־MPR%s."
 
 #: html/home.php
 #, php-format
@@ -225,9 +225,9 @@ msgstr "הבהרה"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "חבילות AUR הן תוכן שנוצר על ידי המשתמשים. כל שימוש בקבצים שסופקו הוא על אחריותך בלבד."
+msgstr "חבילות MPR הן תוכן שנוצר על ידי המשתמשים. כל שימוש בקבצים שסופקו הוא על אחריותך בלבד."
 
 #: html/home.php
 msgid "Learn more..."
@@ -264,7 +264,7 @@ msgstr "בקשת מחיקה"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr "ניתן לבקש הסרת חבילה ממאגר המשתמשים של ארץ׳. אין להשתמש בזה אם יש תקלה בחבילה וניתן לתקן אותה בקלות. במקום זאת, יש ליצור קשר עם מתחזק החבילה ולהגיש בקשת יתומה אם יש צורך."
@@ -293,14 +293,14 @@ msgstr "שליחת חבילות"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Git על גבי SSH היא התשתית העדכנית להגשת חבילות ל־AUR. ניתן לעיין בסעיף %sהגשת חבילות%s בעמוד Arch User Repository ב־ArchWiki לקבלת פרטים נוספים."
+msgstr "Git על גבי SSH היא התשתית העדכנית להגשת חבילות ל־MPR. ניתן לעיין בסעיף %sהגשת חבילות%s בעמוד makedeb Package Repository ב־ArchWiki לקבלת פרטים נוספים."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "טביעות האצבע מסוג SSH הבאות נמצאות בשימוש עבור AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "טביעות האצבע מסוג SSH הבאות נמצאות בשימוש עבור MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -309,10 +309,10 @@ msgstr "דיון"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "הדיון הכללי על מאגר המשתמשים של ארץ׳ (AUR) ומבנה המשתמשים המהימנים מתנהל ברשימה %saur-general%s. לדיון בנוגע לפיתוח של המנשק של AUR, יש להשתמש ברשימה %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "הדיון הכללי על מאגר המשתמשים של ארץ׳ (MPR) ומבנה המשתמשים המהימנים מתנהל ברשימה %saur-general%s. לדיון בנוגע לפיתוח של המנשק של MPR, יש להשתמש ברשימה %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -321,11 +321,11 @@ msgstr "דיווח על באגים"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "אם נתקלת בתקלה במנשק הדפדפן של AUR, נא להגיש דיווח על תקלה ב%sמערכת ניהול התקלות%s שלנו. יש להשתמש במערכת ניהול התקלות כדי לדווח על תקלות במנשק הדפדפן %sבלבד%s. כדי לדווח על תקלות עם אריזה יש ליצור קשר עם מתחזק החבילה או להשאיר הערה בעמוד החבילה בהתאם."
+msgstr "אם נתקלת בתקלה במנשק הדפדפן של MPR, נא להגיש דיווח על תקלה ב%sמערכת ניהול התקלות%s שלנו. יש להשתמש במערכת ניהול התקלות כדי לדווח על תקלות במנשק הדפדפן %sבלבד%s. כדי לדווח על תקלות עם אריזה יש ליצור קשר עם מתחזק החבילה או להשאיר הערה בעמוד החבילה בהתאם."
 
 #: html/home.php
 msgid "Package Search"
@@ -499,8 +499,8 @@ msgstr "מחיקת חבילה"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "ניתן להשתמש בטופס זה כדי למחוק את בסיס החבילה %s%s%s ואת החבילות הבאות מ־AUR:"
+"from the MPR: "
+msgstr "ניתן להשתמש בטופס זה כדי למחוק את בסיס החבילה %s%s%s ואת החבילות הבאות מ־MPR:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1134,8 +1134,8 @@ msgstr "הבקשה נסגרה בהצלחה."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "ניתן להשתמש בטופס זה כדי למחוק את חשבון ה־AUR בשם %s לצמיתות."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "ניתן להשתמש בטופס זה כדי למחוק את חשבון ה־MPR בשם %s לצמיתות."
 
 #: template/account_delete.php
 #, php-format
@@ -1295,10 +1295,10 @@ msgstr "הסתרת כתובת דוא״ל"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
-msgstr "אם בחירתך תהיה שלא להסתיר את כתובת הדוא״ל שלך, היא תהיה גלויה לכלל המשתמשים ב־AUR. בחירה הפוכה תגרום לכך שהכתובת תהיה גלויה בפני חברי הסגל של Arch לינוקס בלבד."
+msgstr "אם בחירתך תהיה שלא להסתיר את כתובת הדוא״ל שלך, היא תהיה גלויה לכלל המשתמשים ב־MPR. בחירה הפוכה תגרום לכך שהכתובת תהיה גלויה בפני חברי הסגל של Arch לינוקס בלבד."
 
 #: template/account_edit_form.php
 msgid "Backup Email Address"
@@ -1344,7 +1344,7 @@ msgstr "הקלדת הססמה מחדש"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "המידע הבא נחוץ רק אם ברצונך להגיש חבילות למאגר החבילות של ארץ׳."
 
 #: template/account_edit_form.php
@@ -1377,9 +1377,9 @@ msgstr "הססמה הנוכחית שלך"
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
-msgstr "כדי להגן על AUR מפני יצירה אוטומטית של חשבונות, אנו מבקשים ממך לציין מה הפלט של הפקודה הבאה:"
+msgstr "כדי להגן על MPR מפני יצירה אוטומטית של חשבונות, אנו מבקשים ממך לציין מה הפלט של הפקודה הבאה:"
 
 #: template/account_edit_form.php
 msgid "Answer"
@@ -1598,9 +1598,9 @@ msgstr "הוספת תגובה"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
-msgstr "מזהי הגשות של Git שמפנים להגשות במאגר החבילות של AUR וכתובות מומרים אוטומטית לקישורים."
+msgstr "מזהי הגשות של Git שמפנים להגשות במאגר החבילות של MPR וכתובות מומרים אוטומטית לקישורים."
 
 #: template/pkg_comment_form.php
 #, php-format
@@ -2125,8 +2125,8 @@ msgid "Back"
 msgstr "חזרה"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "איפוס ססמה ב־AUR"
+msgid "MPR Password Reset"
+msgstr "איפוס ססמה ב־MPR"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2137,20 +2137,20 @@ msgid ""
 msgstr "הוגשה בקשה לאיפוס ססמה לחשבון {user} שמקושר לכתובת הדוא״ל שלך. אם ברצונך לאפס את הססמה שלך עליך להיכנס לקישור [1] שלהלן, אם לא ביקשת מוטב להתעלם מההודעה הזאת ולא יתבצע אף שינוי."
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr "ברוך בואך למאגר בתחזוקת המשתמשים של Arch"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr "ברוך הבא למאגר חבילות המשתמשים של Arch! כדי להגדיר ססמה ראשונית לחשבון החדש שלך נא ללחוץ על הקישור [1] שלהלן. אם הקישור לא עובד, נא לנסות להעתיק ולהדביק אותו בדפדפן."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "הערה ב־AUR על {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "הערה ב־MPR על {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2166,8 +2166,8 @@ msgstr "אם לא מעניין אותך לקבל יותר הודעות על הח
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "עדכון בחבילת AUR:‏ {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "עדכון בחבילת MPR:‏ {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2176,8 +2176,8 @@ msgstr "נדחפה הגשה חדשה מאת {user} [1] אל {pkgbase} [2]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "התראת חבילה לא עדכנית ב־AUR עבור {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "התראת חבילה לא עדכנית ב־MPR עבור {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2186,8 +2186,8 @@ msgstr "החבילה שלך {pkgbase} [1] סומנה כלא עדכנית על י
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "הודעת בעלות ב־AUR על {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "הודעת בעלות ב־MPR על {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2201,8 +2201,8 @@ msgstr "החבילה {pkgbase} [1] נושלה על ידי {user} [2]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "התראה למתחזקי משנה ב־AUR של {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "התראה למתחזקי משנה ב־MPR של {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2216,8 +2216,8 @@ msgstr "הוסרת מרשימת מתחזקי המשנה עבור {pkgbase} [1]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "חבילה נמחקה ב־AUR‏: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "חבילה נמחקה ב־MPR‏: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Lukas Fleischer <transifex@cryptocrack.de>, 2011
@@ -198,7 +198,7 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
 msgstr ""
 
@@ -262,7 +262,7 @@ msgstr ""
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr ""
@@ -291,13 +291,13 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr ""
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
 msgstr ""
 
 #: html/home.php
@@ -307,9 +307,9 @@ msgstr "Rasprava"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
 msgstr ""
 
 #: html/home.php
@@ -319,8 +319,8 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -497,7 +497,7 @@ msgstr ""
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
+"from the MPR: "
 msgstr ""
 
 #: html/pkgdel.php
@@ -1132,7 +1132,7 @@ msgstr ""
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr ""
 
 #: template/account_delete.php
@@ -1293,7 +1293,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1342,7 +1342,7 @@ msgstr "Ponovno upišite lozinku"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr ""
 
 #: template/account_edit_form.php
@@ -1375,7 +1375,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2118,7 +2118,7 @@ msgid "Back"
 msgstr "Natrag"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2130,19 +2130,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2159,7 +2159,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2169,7 +2169,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2179,7 +2179,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2194,7 +2194,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2209,7 +2209,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Balló György <ballogyor@gmail.com>, 2013
@@ -201,9 +201,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Üdvözlünk az AUR-ban! További információért olvasd el az %sAUR felhasználói irányelveket%s és az %sAUR TU irányelveket%s."
+msgstr "Üdvözlünk az MPR-ban! További információért olvasd el az %sMPR felhasználói irányelveket%s és az %sMPR TU irányelveket%s."
 
 #: html/home.php
 #, php-format
@@ -226,9 +226,9 @@ msgstr "NYILATKOZAT"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Az AUR csomagok felhasználók által készített tartalmak. A szolgáltatott fájlok használata csak saját felelősségre."
+msgstr "Az MPR csomagok felhasználók által készített tartalmak. A szolgáltatott fájlok használata csak saját felelősségre."
 
 #: html/home.php
 msgid "Learn more..."
@@ -265,7 +265,7 @@ msgstr "Törlési kérelem"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr "Egy csomag Arch User Repositoriból való törlésének kérése. Kérünk, ne használd ezt, ha a csomag törött, és könnyen javítható. Ehelyett vedd fel a kapcsolatot a csomag karbantartójával, és tölts ki megtagadási kérelmet, ha szükséges."
@@ -294,14 +294,14 @@ msgstr "Csomagok beküldése"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Jelenleg SSH-n keresztüli Git használandó a csomagok beküldéséhez az AUR-ba. További részletekért lásd a %sCsomagok beküldése%s szakaszt az Arch User Repository ArchWiki oldalon."
+msgstr "Jelenleg SSH-n keresztüli Git használandó a csomagok beküldéséhez az MPR-ba. További részletekért lásd a %sCsomagok beküldése%s szakaszt az makedeb Package Repository ArchWiki oldalon."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Az alábbi SSH ujjlenyomatokat használjuk az AUR-hoz:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Az alábbi SSH ujjlenyomatokat használjuk az MPR-hoz:"
 
 #: html/home.php
 msgid "Discussion"
@@ -310,10 +310,10 @@ msgstr "Megbeszélés"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Az Arch User Repositoryval (AUR) és a Trusted User struktúrával kapcsolatos általános tanácskozás helye az %saur-general%s. Az AUR webes felületének fejlesztésével kapcsolatos tanácskozáshoz az %saur-dev%s levelezőlista használandó."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Az makedeb Package Repositoryval (MPR) és a Trusted User struktúrával kapcsolatos általános tanácskozás helye az %saur-general%s. Az MPR webes felületének fejlesztésével kapcsolatos tanácskozáshoz az %saur-dev%s levelezőlista használandó."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -322,11 +322,11 @@ msgstr "Hibajelentés"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Ha találsz egy hibát az AUR webes felületén, kérünk, tölts ki egy hibajelentést a %shibakövetőnkben%s. A hibakövetőt %scsak%s az AUR webes felületén található hibák jelentésére használd. Csomagolási hibák jelentéséhez lépj kapcsolatba a csomag fenntartójával, vagy hagyj egy hozzászólást a megfelelő csomag oldalán."
+msgstr "Ha találsz egy hibát az MPR webes felületén, kérünk, tölts ki egy hibajelentést a %shibakövetőnkben%s. A hibakövetőt %scsak%s az MPR webes felületén található hibák jelentésére használd. Csomagolási hibák jelentéséhez lépj kapcsolatba a csomag fenntartójával, vagy hagyj egy hozzászólást a megfelelő csomag oldalán."
 
 #: html/home.php
 msgid "Package Search"
@@ -500,8 +500,8 @@ msgstr "Csomag törlése"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Használd ezt az űrlapot a(z) %s%s%s alapcsomag és az alábbi csomagok törléséhez az AUR-ból:"
+"from the MPR: "
+msgstr "Használd ezt az űrlapot a(z) %s%s%s alapcsomag és az alábbi csomagok törléséhez az MPR-ból:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1135,8 +1135,8 @@ msgstr "Kérelem sikeresen lezárva."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Ez az űrlap %s AUR fiókjának végleges törléséhez használható."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Ez az űrlap %s MPR fiókjának végleges törléséhez használható."
 
 #: template/account_delete.php
 #, php-format
@@ -1296,7 +1296,7 @@ msgstr "E-mail cím elrejtése"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1345,8 +1345,8 @@ msgstr "Megismételt jelszó"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "Az alábbi információ csak akkor szükséges, ha csomagokat szeretnél beküldeni az Arch User Repositoryba."
+" the makedeb Package Repository."
+msgstr "Az alábbi információ csak akkor szükséges, ha csomagokat szeretnél beküldeni az makedeb Package Repositoryba."
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1378,7 +1378,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr "Hosszászólás"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2116,7 +2116,7 @@ msgid "Back"
 msgstr "Vissza"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2128,19 +2128,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2157,7 +2157,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2167,7 +2167,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2177,7 +2177,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2192,7 +2192,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2207,7 +2207,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/it.po
+++ b/po/it.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Giovanni Scafora <giovanni@archlinux.org>, 2011-2015
@@ -201,9 +201,9 @@ msgstr "Cerca i pacchetti da me co-mantenuti"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Benvenuto in AUR! Per maggiori informazioni, leggi le %sAUR User Guidelines%s e le %sAUR TU Guidelines%s."
+msgstr "Benvenuto in MPR! Per maggiori informazioni, leggi le %sMPR User Guidelines%s e le %sMPR TU Guidelines%s."
 
 #: html/home.php
 #, php-format
@@ -226,9 +226,9 @@ msgstr "AVVISO"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "i pacchetti presenti in AUR sono stati inviati dagli utenti. Usali a tuo rischio e pericolo."
+msgstr "i pacchetti presenti in MPR sono stati inviati dagli utenti. Usali a tuo rischio e pericolo."
 
 #: html/home.php
 msgid "Learn more..."
@@ -265,10 +265,10 @@ msgstr "Richiesta di rimozione di un pacchetto"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "richiesta per rimuovere un pacchetto dall'Arch User Repository. Non usare questo tipo di richiesta se un pacchetto non funziona e se può essere sistemato facilmente. Contatta il manutentore del pacchetto e, se necessario, invia una richiesta per renderlo orfano."
+msgstr "richiesta per rimuovere un pacchetto dall'makedeb Package Repository. Non usare questo tipo di richiesta se un pacchetto non funziona e se può essere sistemato facilmente. Contatta il manutentore del pacchetto e, se necessario, invia una richiesta per renderlo orfano."
 
 #: html/home.php
 msgid "Merge Request"
@@ -294,14 +294,14 @@ msgstr "Invio dei pacchetti"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Per inviare i pacchetti in AUR, adesso, si utilizza Git via SSH. Per maggiori informazioni, vedi la sezione %sInviare i pacchetti%s della pagina Arch User Repository dell'ArchWiki."
+msgstr "Per inviare i pacchetti in MPR, adesso, si utilizza Git via SSH. Per maggiori informazioni, vedi la sezione %sInviare i pacchetti%s della pagina makedeb Package Repository dell'ArchWiki."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Per AUR si usano le seguenti fingerprint SSH:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Per MPR si usano le seguenti fingerprint SSH:"
 
 #: html/home.php
 msgid "Discussion"
@@ -310,10 +310,10 @@ msgstr "Discussione"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "La discussione generale sull'Arch User Repository (AUR) e sulla struttura dei TU avviene in %saur-general%s. Per la discussione relativa allo sviluppo dell'interfaccia web di AUR, utilizza la lista di discussione %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "La discussione generale sull'makedeb Package Repository (MPR) e sulla struttura dei TU avviene in %saur-general%s. Per la discussione relativa allo sviluppo dell'interfaccia web di MPR, utilizza la lista di discussione %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -322,11 +322,11 @@ msgstr "Segnalazione di un bug"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Se trovi un bug nell'interfaccia web di AUR, invia un report al nostro %sbug tracker%s. Usa il tracker %ssolo%s per inviare i bug di AUR. Per segnalare bug inerenti alla pacchettizzazione, contatta il manutentore oppure lascia un commento nella pagina del pacchetto."
+msgstr "Se trovi un bug nell'interfaccia web di MPR, invia un report al nostro %sbug tracker%s. Usa il tracker %ssolo%s per inviare i bug di MPR. Per segnalare bug inerenti alla pacchettizzazione, contatta il manutentore oppure lascia un commento nella pagina del pacchetto."
 
 #: html/home.php
 msgid "Package Search"
@@ -500,8 +500,8 @@ msgstr "Elimina il pacchetto"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Usa questo modulo per eliminare il pacchetto base %s%s%s e i seguenti pacchetti da AUR:"
+"from the MPR: "
+msgstr "Usa questo modulo per eliminare il pacchetto base %s%s%s e i seguenti pacchetti da MPR:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1135,8 +1135,8 @@ msgstr "La richiesta è stata chiusa con successo."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Puoi usare questo modulo per eliminare definitivamente da AUR l'account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Puoi usare questo modulo per eliminare definitivamente da MPR l'account %s."
 
 #: template/account_delete.php
 #, php-format
@@ -1296,7 +1296,7 @@ msgstr "Nascondi l'indirizzo email"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1345,8 +1345,8 @@ msgstr "Riscrivi la password"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "La seguente informazione è richiesta solo se vuoi inviare i pacchetti nell'Arch User Repository."
+" the makedeb Package Repository."
+msgstr "La seguente informazione è richiesta solo se vuoi inviare i pacchetti nell'makedeb Package Repository."
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1378,7 +1378,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr "Aggiungi un commento"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2116,8 +2116,8 @@ msgid "Back"
 msgstr "Precedente"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "Ripristino Password di AUR"
+msgid "MPR Password Reset"
+msgstr "Ripristino Password di MPR"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2128,19 +2128,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
-msgstr "Benvenuto nel Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
+msgstr "Benvenuto nel makedeb Package Repository"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
-msgstr "Benvenuto nel Arch User Repository! Per impostare una password iniziale per il tuo nuovo account, per favore segui il collegamento [1] sottostante. Se il collegamento non funziona, prova a copiarlo e incollarlo nel tuo browser."
+msgstr "Benvenuto nel makedeb Package Repository! Per impostare una password iniziale per il tuo nuovo account, per favore segui il collegamento [1] sottostante. Se il collegamento non funziona, prova a copiarlo e incollarlo nel tuo browser."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2157,7 +2157,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2167,7 +2167,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2177,7 +2177,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2192,7 +2192,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2207,7 +2207,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # kusakata, 2013
@@ -201,9 +201,9 @@ msgstr "共同メンテしているパッケージを検索"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "AUR にようこそ！AUR についての詳しい情報は %sAUR User Guidelines%s や %sAUR TU Guidelines%s を読んで下さい。"
+msgstr "MPR にようこそ！MPR についての詳しい情報は %sMPR User Guidelines%s や %sMPR TU Guidelines%s を読んで下さい。"
 
 #: html/home.php
 #, php-format
@@ -226,9 +226,9 @@ msgstr "免責事項"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "AUR のパッケージはユーザーによって作成されたものです。自己責任で使用して下さい。"
+msgstr "MPR のパッケージはユーザーによって作成されたものです。自己責任で使用して下さい。"
 
 #: html/home.php
 msgid "Learn more..."
@@ -265,10 +265,10 @@ msgstr "削除リクエスト"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Arch User Repository からパッケージを削除するようにリクエストします。パッケージが壊れていて、その不具合を簡単に修正できるような場合、このリクエストは使わないで下さい。代わりに、パッケージのメンテナに連絡したり、必要に応じて孤児リクエストを送りましょう。"
+msgstr "makedeb Package Repository からパッケージを削除するようにリクエストします。パッケージが壊れていて、その不具合を簡単に修正できるような場合、このリクエストは使わないで下さい。代わりに、パッケージのメンテナに連絡したり、必要に応じて孤児リクエストを送りましょう。"
 
 #: html/home.php
 msgid "Merge Request"
@@ -294,14 +294,14 @@ msgstr "パッケージの投稿"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "現在 AUR にパッケージを送信するときは SSH を介して Git を使うことになっています。詳しくは ArchWiki の Arch User Repository のページの%sパッケージの投稿%sセクションを見て下さい。"
+msgstr "現在 MPR にパッケージを送信するときは SSH を介して Git を使うことになっています。詳しくは ArchWiki の makedeb Package Repository のページの%sパッケージの投稿%sセクションを見て下さい。"
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "AUR では以下の SSH フィンガープリントが使われます:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "MPR では以下の SSH フィンガープリントが使われます:"
 
 #: html/home.php
 msgid "Discussion"
@@ -310,10 +310,10 @@ msgstr "議論"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Arch User Repository (AUR) や Trusted User に関する一般的な議論は %saur-general%s で行って下さい。AUR ウェブインターフェイスの開発に関しては、%saur-dev%s メーリングリストを使用します。"
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "makedeb Package Repository (MPR) や Trusted User に関する一般的な議論は %saur-general%s で行って下さい。MPR ウェブインターフェイスの開発に関しては、%saur-dev%s メーリングリストを使用します。"
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -322,11 +322,11 @@ msgstr "バグレポート"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "AUR のウェブインターフェイスにバグを発見した時は%sバグトラッカー%sにバグを報告してください。トラッカーを使って報告できるバグは AUR ウェブインターフェイスのバグ%sだけ%sです。パッケージのバグを報告するときはパッケージのメンテナに連絡するか該当するパッケージのページにコメントを投稿してください。"
+msgstr "MPR のウェブインターフェイスにバグを発見した時は%sバグトラッカー%sにバグを報告してください。トラッカーを使って報告できるバグは MPR ウェブインターフェイスのバグ%sだけ%sです。パッケージのバグを報告するときはパッケージのメンテナに連絡するか該当するパッケージのページにコメントを投稿してください。"
 
 #: html/home.php
 msgid "Package Search"
@@ -500,8 +500,8 @@ msgstr "パッケージを削除"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "AUR からパッケージベース %s%s%s と以下のパッケージを削除するにはこのフォームを使って下さい:"
+"from the MPR: "
+msgstr "MPR からパッケージベース %s%s%s と以下のパッケージを削除するにはこのフォームを使って下さい:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1135,8 +1135,8 @@ msgstr "リクエストのクローズが完了しました。"
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "このフォームを使って AUR アカウント %s を恒久的に削除することができます。"
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "このフォームを使って MPR アカウント %s を恒久的に削除することができます。"
 
 #: template/account_delete.php
 #, php-format
@@ -1296,10 +1296,10 @@ msgstr "メールアドレスを非公開にする"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
-msgstr "メールアドレスを非公開にしない場合、登録されている AUR ユーザー全てから閲覧できる状態になります。メールアドレスを非表示にした場合、Arch Linux のスタッフからしか表示されません。"
+msgstr "メールアドレスを非公開にしない場合、登録されている MPR ユーザー全てから閲覧できる状態になります。メールアドレスを非表示にした場合、Arch Linux のスタッフからしか表示されません。"
 
 #: template/account_edit_form.php
 msgid "Backup Email Address"
@@ -1345,8 +1345,8 @@ msgstr "パスワードの再入力"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "以下の情報は Arch User Repository にパッケージを送信したい場合にのみ必要になります。"
+" the makedeb Package Repository."
+msgstr "以下の情報は makedeb Package Repository にパッケージを送信したい場合にのみ必要になります。"
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1378,9 +1378,9 @@ msgstr "現在のパスワード"
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
-msgstr "機械的なアカウント作成から AUR を保護するため、次のコマンドの出力結果を入力してください:"
+msgstr "機械的なアカウント作成から MPR を保護するため、次のコマンドの出力結果を入力してください:"
 
 #: template/account_edit_form.php
 msgid "Answer"
@@ -1596,9 +1596,9 @@ msgstr "コメントを投稿する"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
-msgstr "AUR パッケージリポジトリの Git コミット ID や URL は自動的にリンクに変換されます。"
+msgstr "MPR パッケージリポジトリの Git コミット ID や URL は自動的にリンクに変換されます。"
 
 #: template/pkg_comment_form.php
 #, php-format
@@ -2111,8 +2111,8 @@ msgid "Back"
 msgstr "前へ"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "AUR パスワードのリセット"
+msgid "MPR Password Reset"
+msgstr "MPR パスワードのリセット"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2123,20 +2123,20 @@ msgid ""
 msgstr "あなたのメールアドレスと関連付けられたアカウント {user} のパスワードのリセットリクエストが送信されました。パスワードをリセットしたいときは下のリンク [1] を開いて下さい、そうでない場合はこのメッセージは無視して下さい。"
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
-msgstr "Arch User Repository にようこそ"
+msgid "Welcome to the makedeb Package Repository"
+msgstr "makedeb Package Repository にようこそ"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
-msgstr "Arch User Repository にようこそ！アカウントのパスワードを設定するために、下のリンク [1] をクリックしてください。リンクを押せないときは、一旦ブラウザにURLをコピーしてください。"
+msgstr "makedeb Package Repository にようこそ！アカウントのパスワードを設定するために、下のリンク [1] をクリックしてください。リンクを押せないときは、一旦ブラウザにURLをコピーしてください。"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "{pkgbase} の AUR コメント"
+msgid "MPR Comment for {pkgbase}"
+msgstr "{pkgbase} の MPR コメント"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2152,8 +2152,8 @@ msgstr "このパッケージの通知を受け取りたくない場合は、パ
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "AUR パッケージアップデート: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "MPR パッケージアップデート: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2162,8 +2162,8 @@ msgstr "{user} [1] は {pkgbase} [2] に新しいコミットを投稿しまし�
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "{pkgbase} の AUR Out-of-date 通知"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "{pkgbase} の MPR Out-of-date 通知"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2172,8 +2172,8 @@ msgstr "あなたのパッケージ {pkgbase} [1] は {user} [2] によって ou
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "{pkgbase} の AUR 所有者通知"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "{pkgbase} の MPR 所有者通知"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2187,8 +2187,8 @@ msgstr "パッケージ {pkgbase} [1] は {user} [2] から放棄されました
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "{pkgbase} の AUR 共同メンテナ通知"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "{pkgbase} の MPR 共同メンテナ通知"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2202,8 +2202,8 @@ msgstr "あなたは {pkgbase} [1] の共同メンテナリストから削除さ
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "AUR パッケージ削除: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "MPR パッケージ削除: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Alexander F Rødseth <rodseth@gmail.com>, 2015,2017-2019
@@ -203,9 +203,9 @@ msgstr "Søk etter pakker jeg er med på å vedlikeholde"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Velkommen til AUR! Vennligst les %sAUR Brukerveiledning%s og %sAUR TU Veiledning%s for mer informasjon."
+msgstr "Velkommen til MPR! Vennligst les %sMPR Brukerveiledning%s og %sMPR TU Veiledning%s for mer informasjon."
 
 #: html/home.php
 #, php-format
@@ -228,9 +228,9 @@ msgstr "ANSVARSFRASKRIVELSE"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Pakker i AUR kan lages av hvem som helst. All bruk av filer herfra skjer på eget ansvar."
+msgstr "Pakker i MPR kan lages av hvem som helst. All bruk av filer herfra skjer på eget ansvar."
 
 #: html/home.php
 msgid "Learn more..."
@@ -267,10 +267,10 @@ msgstr "Forespør sletting"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Forespør at pakken fjernes fra Arch User Repository. Ikke gjør dette hvis pakken er ødelagt og lett kan fikses. Ta kontakt med vedlikeholderen i stedet, eller forespør at pakken gjøres eierløs."
+msgstr "Forespør at pakken fjernes fra makedeb Package Repository. Ikke gjør dette hvis pakken er ødelagt og lett kan fikses. Ta kontakt med vedlikeholderen i stedet, eller forespør at pakken gjøres eierløs."
 
 #: html/home.php
 msgid "Merge Request"
@@ -296,14 +296,14 @@ msgstr "Innsending av pakker"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Git over SSH brukes nå for å sende inn pakker til AUR. Ta en titt på %sSubmitting packages%s-seksjonen til Arch User Repository sin wikiside for nærmere detaljer."
+msgstr "Git over SSH brukes nå for å sende inn pakker til MPR. Ta en titt på %sSubmitting packages%s-seksjonen til makedeb Package Repository sin wikiside for nærmere detaljer."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Følgende SSH-fingeravtrykk brukes for AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Følgende SSH-fingeravtrykk brukes for MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -312,10 +312,10 @@ msgstr "Diskusjon"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Generell diskusjon rundt Arch sitt brukerstyrte pakkebibliotek (AUR) og strukturen rundt betrodde brukere, foregår på %saur-general%s. For diskusjoner relatert til utviklingen av AUR web-grensesnittet, bruk %saur-dev%s e-postlisten."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Generell diskusjon rundt Arch sitt brukerstyrte pakkebibliotek (MPR) og strukturen rundt betrodde brukere, foregår på %saur-general%s. For diskusjoner relatert til utviklingen av MPR web-grensesnittet, bruk %saur-dev%s e-postlisten."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -324,11 +324,11 @@ msgstr "Feilrapportering"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Vennligst fyll ut en feilrapport i %sfeilrapporteringssystemet%s dersom du finner en feil i AUR sitt web-grensesnitt. Bruk denne %skun%s til å rapportere feil som gjelder AUR sitt web-grensesnitt. For å rapportere feil med pakker, kontakt personen som vedlikeholder pakken eller legg igjen en kommentar på siden til den aktuelle pakken."
+msgstr "Vennligst fyll ut en feilrapport i %sfeilrapporteringssystemet%s dersom du finner en feil i MPR sitt web-grensesnitt. Bruk denne %skun%s til å rapportere feil som gjelder MPR sitt web-grensesnitt. For å rapportere feil med pakker, kontakt personen som vedlikeholder pakken eller legg igjen en kommentar på siden til den aktuelle pakken."
 
 #: html/home.php
 msgid "Package Search"
@@ -502,8 +502,8 @@ msgstr "Slett pakke"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Bruk dette skjemaet for å slette basispakken %s%s%s og følgende pakker fra AUR:"
+"from the MPR: "
+msgstr "Bruk dette skjemaet for å slette basispakken %s%s%s og følgende pakker fra MPR:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1137,8 +1137,8 @@ msgstr "Forespørselen ble lukket."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Dette skjemaet kan brukes for å permanent slette AUR kontoen %s."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Dette skjemaet kan brukes for å permanent slette MPR kontoen %s."
 
 #: template/account_delete.php
 #, php-format
@@ -1298,7 +1298,7 @@ msgstr "Gjem e-postadresse"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1347,7 +1347,7 @@ msgstr "Skriv inn passordet på nytt"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "Følgende informasjon behøves bare hvis du har tenkt til å sende inn pakker til Arch sitt brukerstyrte pakkebibliotek."
 
 #: template/account_edit_form.php
@@ -1380,7 +1380,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1599,7 +1599,7 @@ msgstr "Legg til kommentar"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2118,8 +2118,8 @@ msgid "Back"
 msgstr "Tilbake"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "Tilbakestill AUR passordet"
+msgid "MPR Password Reset"
+msgstr "Tilbakestill MPR passordet"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2130,20 +2130,20 @@ msgid ""
 msgstr "Vi fikk en forespørsel om å nullstille passordet for brukerkontoen {user}, som hører til din e-post adresse. Dersom du ikke ønsker å nullstille passordet kan du ignorere denne beskjeden. Dersom du ønsker å nullstille passordet, følg lenken [1] nedenfor."
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr "Velkommen til pakkebrønnen for brukerinnsendte pakker, for Arch."
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr "Velkommen til pakkebrønnen for brukerinnsendte pakker, for Arch! For å sette et nytt passord for din konto, vennligst klikk på lenken [1] nedenfor. Dersom den ikke fungerer, forsøk å kopiere og så lime den inn i din nettleser."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "AUR kommentar for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "MPR kommentar for {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2159,8 +2159,8 @@ msgstr "Hvis du ikke lenger vil motta beskjeder om denne pakken, vennligst gå t
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "AUR pakkeoppdatering: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "MPR pakkeoppdatering: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2169,8 +2169,8 @@ msgstr "{user} [1] dyttet en ny endring til {pkgbase} [2]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "AUR beskjed om utdatert pakke for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "MPR beskjed om utdatert pakke for {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2179,8 +2179,8 @@ msgstr "Pakken din {pkgbase} [1] har blitt flagget som utdatert av {user} [2]:"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "AUR eierskapsbeskjed for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "MPR eierskapsbeskjed for {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2194,8 +2194,8 @@ msgstr "Pakken {pkgbase} [1] ble forlatt av {user} [2]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "AUR bonusforeldrebeskjed for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "MPR bonusforeldrebeskjed for {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2209,8 +2209,8 @@ msgstr "Du ble fjernet som bonusforelder for {pkgbase} [1]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "AUR pakken ble slettet: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "MPR pakken ble slettet: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Heimen Stoffels <vistausss@outlook.com>, 2015
@@ -202,9 +202,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Welkom bij de AUR! Lees de %sAUR-gebruikersrichtlijnen%s en de %sAUR-ontwikkelaarsrichtlijnen%s voor meer informatie."
+msgstr "Welkom bij de MPR! Lees de %sMPR-gebruikersrichtlijnen%s en de %sMPR-ontwikkelaarsrichtlijnen%s voor meer informatie."
 
 #: html/home.php
 #, php-format
@@ -227,7 +227,7 @@ msgstr "DISCLAIMER"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
 msgstr ""
 
@@ -266,10 +266,10 @@ msgstr "Verwijderaanvraag"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Verzoek om een pakket uit de Arch User Repository te laten verwijderen. Gebruik dit niet als een pakket niet naar behoren functioneert en eenvoudig gerepareerd kan worden. Neem in zo'n geval contact op met de pakketontwikkelaar en open zo nodig een weesverzoek."
+msgstr "Verzoek om een pakket uit de makedeb Package Repository te laten verwijderen. Gebruik dit niet als een pakket niet naar behoren functioneert en eenvoudig gerepareerd kan worden. Neem in zo'n geval contact op met de pakketontwikkelaar en open zo nodig een weesverzoek."
 
 #: html/home.php
 msgid "Merge Request"
@@ -295,14 +295,14 @@ msgstr "Het bijdragen van pakketten"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Git via SSA is nu in gebruik om pakketten bij te dragen aan de AUR. Zie de %sHet bijdragen van pakketten%s-gedeelte van de Arch User Repository ArchWiki-pagina voor meer details."
+msgstr "Git via SSA is nu in gebruik om pakketten bij te dragen aan de MPR. Zie de %sHet bijdragen van pakketten%s-gedeelte van de makedeb Package Repository ArchWiki-pagina voor meer details."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "De volgende SSH-vingerafdrukken worden gebruikt voor de AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "De volgende SSH-vingerafdrukken worden gebruikt voor de MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -311,10 +311,10 @@ msgstr "Discussie"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Algemene discussies met betrekking tot de Arch User Repository (AUR) en de opzet van Trusted Users vinden plaats op %saur-general%s. Voor discussies gerelateerd aan de ontwikkeling van de AUR web interface, gebruik de %saur-dev%s mailinglijst."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Algemene discussies met betrekking tot de makedeb Package Repository (MPR) en de opzet van Trusted Users vinden plaats op %saur-general%s. Voor discussies gerelateerd aan de ontwikkeling van de MPR web interface, gebruik de %saur-dev%s mailinglijst."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -323,8 +323,8 @@ msgstr "Bug-rapportage"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -501,8 +501,8 @@ msgstr "Verwijder Pakket"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Gebruik dit formulier om basispakket %s%s%s te verwijderen van AUR met inbegrip van de volgende pakketten:"
+"from the MPR: "
+msgstr "Gebruik dit formulier om basispakket %s%s%s te verwijderen van MPR met inbegrip van de volgende pakketten:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1136,8 +1136,8 @@ msgstr "Verzoek succesvol gesloten."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Gebruik dit formulier om permanent AUR account %s te verwijderen."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Gebruik dit formulier om permanent MPR account %s te verwijderen."
 
 #: template/account_delete.php
 #, php-format
@@ -1297,7 +1297,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1346,8 +1346,8 @@ msgstr "Voer wachtwoord opnieuw in"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "De volgende informatie is alleen verplicht als u pakketten aan de Arch User Repository wilt toevoegen."
+" the makedeb Package Repository."
+msgstr "De volgende informatie is alleen verplicht als u pakketten aan de makedeb Package Repository wilt toevoegen."
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1379,7 +1379,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1598,7 +1598,7 @@ msgstr "Voeg Comment Toe"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2117,7 +2117,7 @@ msgid "Back"
 msgstr "Terug"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2129,19 +2129,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2158,7 +2158,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2168,7 +2168,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2178,7 +2178,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2193,7 +2193,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2208,7 +2208,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Bartłomiej Piotrowski <spam@bpiotrowski.pl>, 2011
@@ -209,9 +209,9 @@ msgstr "Wyszukaj pakiety, które współ-utrzymuję"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Witamy w AUR! Aby uzyskać więcej informacji, przeczytaj %sInstrukcję Użytkownika AUR%s oraz %sInstrukcję Zaufanego Użytkownika%s."
+msgstr "Witamy w MPR! Aby uzyskać więcej informacji, przeczytaj %sInstrukcję Użytkownika MPR%s oraz %sInstrukcję Zaufanego Użytkownika%s."
 
 #: html/home.php
 #, php-format
@@ -234,9 +234,9 @@ msgstr "ZRZECZENIE"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Pakiety w AUR są tworzone przez użytkowników. Używasz ich na własne ryzyko."
+msgstr "Pakiety w MPR są tworzone przez użytkowników. Używasz ich na własne ryzyko."
 
 #: html/home.php
 msgid "Learn more..."
@@ -273,7 +273,7 @@ msgstr "Prośba o usunięcie"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr ""
@@ -302,14 +302,14 @@ msgstr "Przesyłanie pakietów"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr ""
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Następujące odciski SSH są używane przez AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Następujące odciski SSH są używane przez MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -318,10 +318,10 @@ msgstr "Dyskusja"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Ogólna dyskusja dotycząca Repozytorium Użytkowników Arch (AUR) i struktury Zaufanych Użytkowników odbywa się na %saur-general%s. Dyskusja dotycząca rozwoju interfejsu webowego AUR odbywa się zaś na liście dyskusyjnej %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Ogólna dyskusja dotycząca Repozytorium Użytkowników Arch (MPR) i struktury Zaufanych Użytkowników odbywa się na %saur-general%s. Dyskusja dotycząca rozwoju interfejsu webowego MPR odbywa się zaś na liście dyskusyjnej %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -330,11 +330,11 @@ msgstr "Zgłaszanie błędów"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Jeśli znalazłeś błąd w interfejsie webowym AUR, zgłoś go w naszym %ssystemie śledzenia błędów%s. Używaj go %swyłącznie%s do zgłaszania błędów związanych z interfejsem webowym AUR. Błędy powiązane z pakietami zgłaszaj ich opiekunom lub zostaw komentarz pod odpowiednim pakietem."
+msgstr "Jeśli znalazłeś błąd w interfejsie webowym MPR, zgłoś go w naszym %ssystemie śledzenia błędów%s. Używaj go %swyłącznie%s do zgłaszania błędów związanych z interfejsem webowym MPR. Błędy powiązane z pakietami zgłaszaj ich opiekunom lub zostaw komentarz pod odpowiednim pakietem."
 
 #: html/home.php
 msgid "Package Search"
@@ -508,8 +508,8 @@ msgstr "Usuń pakiet"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Użyj tego formularza, aby usunąć bazę pakietu %s%s%s i następujące pakiety z AUR:"
+"from the MPR: "
+msgstr "Użyj tego formularza, aby usunąć bazę pakietu %s%s%s i następujące pakiety z MPR:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1143,7 +1143,7 @@ msgstr "Pomyślnie zamknięto prośbę."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr "Możesz użyć tego formularza, aby nieodwracalnie usunąć konto %s."
 
 #: template/account_delete.php
@@ -1304,7 +1304,7 @@ msgstr "Ukryj adres e-mail"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1353,7 +1353,7 @@ msgstr "Hasło (ponownie)"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "Następująca informacja jest wymagana jedynie w sytuacji, gdy chcesz przesłać pakiety do Repozytorium Użytkowników Arch."
 
 #: template/account_edit_form.php
@@ -1386,7 +1386,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1607,7 +1607,7 @@ msgstr "Dodaj komentarz"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2134,8 +2134,8 @@ msgid "Back"
 msgstr "Wstecz"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "Reset hasła AUR"
+msgid "MPR Password Reset"
+msgstr "Reset hasła MPR"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2146,20 +2146,20 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
-msgstr "Witamy w AUR: Repozytorium Użytkowników Arch"
+msgid "Welcome to the makedeb Package Repository"
+msgstr "Witamy w MPR: Repozytorium Użytkowników Arch"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "Komentarze AUR do {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "Komentarze MPR do {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2175,8 +2175,8 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "Aktualizacja pakietu AUR: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "Aktualizacja pakietu MPR: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2185,8 +2185,8 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "Powiadomienie AUR o nieaktualnym pakiecie {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "Powiadomienie MPR o nieaktualnym pakiecie {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2195,7 +2195,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2210,7 +2210,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2225,8 +2225,8 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "Usunięty pakiet AUR: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "Usunięty pakiet MPR: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Albino Biasutti Neto Bino <biasuttin@gmail.com>, 2011
@@ -204,9 +204,9 @@ msgstr "Pesquisar por pacotes que eu comantenho"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Bem-vindo ao AUR! Por favor, leia as %sDiretrizes de Usuário do AUR%s e %sDiretrizes de UC do AUR%s para mais informações."
+msgstr "Bem-vindo ao MPR! Por favor, leia as %sDiretrizes de Usuário do MPR%s e %sDiretrizes de UC do MPR%s para mais informações."
 
 #: html/home.php
 #, php-format
@@ -229,9 +229,9 @@ msgstr "AVISO LEGAL"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Os pacotes do AUR são conteúdos produzidos por usuários. Qualquer uso dos arquivos fornecidos é de sua própria conta e risco."
+msgstr "Os pacotes do MPR são conteúdos produzidos por usuários. Qualquer uso dos arquivos fornecidos é de sua própria conta e risco."
 
 #: html/home.php
 msgid "Learn more..."
@@ -268,10 +268,10 @@ msgstr "Requisição de exclusão"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Requisite que um pacote seja removido do Arch User Repository. Por favor, não use esta opção se um pacote está quebrado, mas que pode ser corrigido facilmente. Ao invés disso, contate o mantenedor do pacote e, se necessário, preencha uma requisição para tornar esse pacote órfão."
+msgstr "Requisite que um pacote seja removido do makedeb Package Repository. Por favor, não use esta opção se um pacote está quebrado, mas que pode ser corrigido facilmente. Ao invés disso, contate o mantenedor do pacote e, se necessário, preencha uma requisição para tornar esse pacote órfão."
 
 #: html/home.php
 msgid "Merge Request"
@@ -297,14 +297,14 @@ msgstr "Enviando pacotes"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Git sobre SSH agora é usado para enviar pacotes para o AUR. Veja a seção %sEnviando pacotes%s da página wiki do Arch User Repository para mais detalhes."
+msgstr "Git sobre SSH agora é usado para enviar pacotes para o MPR. Veja a seção %sEnviando pacotes%s da página wiki do makedeb Package Repository para mais detalhes."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "As seguintes impressões digitais SSH são usadas para o AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "As seguintes impressões digitais SSH são usadas para o MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -313,10 +313,10 @@ msgstr "Discussão"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Discussões gerais no que se refere à estrutura do Arch User Repository (AUR) e do Usuário Confiável acontecem no %saur-general%s. Para discussão relacionada ao desenvolvimento do AUR web, use a lista de discussão do %saur-dev%s"
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Discussões gerais no que se refere à estrutura do makedeb Package Repository (MPR) e do Usuário Confiável acontecem no %saur-general%s. Para discussão relacionada ao desenvolvimento do MPR web, use a lista de discussão do %saur-dev%s"
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -325,11 +325,11 @@ msgstr "Relatório de erros"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Se você encontrar um erro na interface web do AUR, por favor preencha um relatório de erro no nosso %sbug tracker%s. Use o tracker para relatar erros encontrados no AUR web, %ssomente%s. Para relatar erros de empacotamento, contate o mantenedor do pacote ou deixe um comentário na página de pacote apropriada."
+msgstr "Se você encontrar um erro na interface web do MPR, por favor preencha um relatório de erro no nosso %sbug tracker%s. Use o tracker para relatar erros encontrados no MPR web, %ssomente%s. Para relatar erros de empacotamento, contate o mantenedor do pacote ou deixe um comentário na página de pacote apropriada."
 
 #: html/home.php
 msgid "Package Search"
@@ -503,8 +503,8 @@ msgstr "Excluir pacote"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Use este formulário para excluir o pacote base %s%s%s e os seguintes pacotes do AUR: "
+"from the MPR: "
+msgstr "Use este formulário para excluir o pacote base %s%s%s e os seguintes pacotes do MPR: "
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1138,8 +1138,8 @@ msgstr "Requisição fechada com sucesso"
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Você pode usar esse formulário para excluir permanentemente a conta %s do AUR."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Você pode usar esse formulário para excluir permanentemente a conta %s do MPR."
 
 #: template/account_delete.php
 #, php-format
@@ -1299,10 +1299,10 @@ msgstr "Ocultar endereço de e-mail"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
-msgstr "Se você não ocultar seu endereço de e-mail, ele ficará visível para todos os usuários registrados do AUR. Se você ocultar seu endereço de e-mail, ele estará visível apenas para membros da equipe do Arch Linux."
+msgstr "Se você não ocultar seu endereço de e-mail, ele ficará visível para todos os usuários registrados do MPR. Se você ocultar seu endereço de e-mail, ele estará visível apenas para membros da equipe do Arch Linux."
 
 #: template/account_edit_form.php
 msgid "Backup Email Address"
@@ -1348,7 +1348,7 @@ msgstr "Re-digite a senha"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "A informação a seguir é necessária apenas se você deseja enviar pacotes para o Repositório de Usuário do Arch."
 
 #: template/account_edit_form.php
@@ -1381,9 +1381,9 @@ msgstr "Sua senha atual"
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
-msgstr "Para proteger o AUR contra a criação automatizada de contas, solicitamos que você forneça o resultado do seguinte comando:"
+msgstr "Para proteger o MPR contra a criação automatizada de contas, solicitamos que você forneça o resultado do seguinte comando:"
 
 #: template/account_edit_form.php
 msgid "Answer"
@@ -1600,9 +1600,9 @@ msgstr "Adicionar comentário"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
-msgstr "Os identificadores de commit Git que fazem referência a commits no repositório de pacote AUR e os URLs são convertidos em links automaticamente."
+msgstr "Os identificadores de commit Git que fazem referência a commits no repositório de pacote MPR e os URLs são convertidos em links automaticamente."
 
 #: template/pkg_comment_form.php
 #, php-format
@@ -2119,8 +2119,8 @@ msgid "Back"
 msgstr "Voltar"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "Redefinir senha do AUR"
+msgid "MPR Password Reset"
+msgstr "Redefinir senha do MPR"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2131,20 +2131,20 @@ msgid ""
 msgstr "Uma requisição de redefinição de senha foi enviada para a conta {user} associada com seu endereço de e-mail. Se deseja redefinir sua senha acesse o link [1] abaixo, do contrário ignore essa mensagem e nada vai acontecer."
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
-msgstr "Bem-vindo ao Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
+msgstr "Bem-vindo ao makedeb Package Repository"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
-msgstr "Bem-vindo ao Arch User Repository! Para definir uma senha inicial para sua nova conta, por favor clique no link [1] abaixo. Se o link não funcionar, tente copiar e colá-lo no seu navegador."
+msgstr "Bem-vindo ao makedeb Package Repository! Para definir uma senha inicial para sua nova conta, por favor clique no link [1] abaixo. Se o link não funcionar, tente copiar e colá-lo no seu navegador."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "Comentário no AUR para {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "Comentário no MPR para {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2160,8 +2160,8 @@ msgstr "Se você não deseja mais receber notificações sobre esse pacote, por 
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "Atualização de pacote do AUR: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "Atualização de pacote do MPR: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2170,8 +2170,8 @@ msgstr "{user} [1] enviou um novo commit ao {pkgbase} [2]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "Notificação de desatualização do AUR para {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "Notificação de desatualização do MPR para {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2180,8 +2180,8 @@ msgstr "Seu pacote {pkgbase} [1] foi marcado como desatualizado por {user} [2]:"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "Notificação de propriedade do AUR para {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "Notificação de propriedade do MPR para {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2195,8 +2195,8 @@ msgstr "O pacote {pkgbase} [1] foi abandonado por {user} [2]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "Notificação de comantenedor do AUR para {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "Notificação de comantenedor do MPR para {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2210,8 +2210,8 @@ msgstr "Você foi removido da lista de comantenedor de {pkgbase} [1]."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "Pacote do AUR excluído: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "Pacote do MPR excluído: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Christophe Silva <christophesilva80@gmail.com>, 2018
@@ -203,9 +203,9 @@ msgstr "Procurar por pacotes que eu co-mantenho"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Bem-vindo ao AUR! Por favor leia as %sOrientações de Utilizador do AUR%s e %sOrientações de TU do AUR%s para mais informações."
+msgstr "Bem-vindo ao MPR! Por favor leia as %sOrientações de Utilizador do MPR%s e %sOrientações de TU do MPR%s para mais informações."
 
 #: html/home.php
 #, php-format
@@ -228,9 +228,9 @@ msgstr "AVISO LEGAL"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Os pacotes AUR são produzidos por utilizadores. O seu uso é por sua conta e risco."
+msgstr "Os pacotes MPR são produzidos por utilizadores. O seu uso é por sua conta e risco."
 
 #: html/home.php
 msgid "Learn more..."
@@ -267,10 +267,10 @@ msgstr "Pedido para Apagar"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Pedido para que um pacote seja removido do Arch User Repository. Por favor não use este pedido se um pacote está danificado e pode ser resolvido facilmente. Contacte o responsável pelo mesmo e faça um Pedido para Tornar Orfão se necessário."
+msgstr "Pedido para que um pacote seja removido do makedeb Package Repository. Por favor não use este pedido se um pacote está danificado e pode ser resolvido facilmente. Contacte o responsável pelo mesmo e faça um Pedido para Tornar Orfão se necessário."
 
 #: html/home.php
 msgid "Merge Request"
@@ -296,14 +296,14 @@ msgstr "Submeter Pacotes"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "O \"Git por SSH\" é usado agora para enviar pacotes para o AUR. Veja a seção %s Submitir pacotes %s secção da página ArchWiki do Repositório de Arquivos do Arch para mais detalhes."
+msgstr "O \"Git por SSH\" é usado agora para enviar pacotes para o MPR. Veja a seção %s Submitir pacotes %s secção da página ArchWiki do Repositório de Arquivos do Arch para mais detalhes."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "As seguintes impressões digitais SSH são usadas para o AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "As seguintes impressões digitais SSH são usadas para o MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -312,10 +312,10 @@ msgstr "Discussão"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "A discussão geral sobre o Repositório do Usuário do Arco (AUR) e a estrutura do Usuário Confiável ocorre em %s aur-general %s. Para discussão relacionada ao desenvolvimento da interface da web AUR, use a lista de emails %s aur-dev %s"
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "A discussão geral sobre o Repositório do Usuário do Arco (MPR) e a estrutura do Usuário Confiável ocorre em %s aur-general %s. Para discussão relacionada ao desenvolvimento da interface da web MPR, use a lista de emails %s aur-dev %s"
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -324,8 +324,8 @@ msgstr "Reportar um Bug"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -502,8 +502,8 @@ msgstr "Eliminar Pacote"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Use este formulário para eliminar o pacote base %s%s%s e os seguintes pacotes do AUR:"
+"from the MPR: "
+msgstr "Use este formulário para eliminar o pacote base %s%s%s e os seguintes pacotes do MPR:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1137,7 +1137,7 @@ msgstr "Pedido fechado com sucesso."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
+msgid "You can use this form to permanently delete the MPR account %s."
 msgstr ""
 
 #: template/account_delete.php
@@ -1298,7 +1298,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1347,7 +1347,7 @@ msgstr "Reintroduza a palavra-passe"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr ""
 
 #: template/account_edit_form.php
@@ -1380,7 +1380,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1599,7 +1599,7 @@ msgstr "Adicionar comentário"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2118,7 +2118,7 @@ msgid "Back"
 msgstr "Anterior"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2130,19 +2130,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2159,7 +2159,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2169,7 +2169,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2179,7 +2179,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2194,7 +2194,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2209,7 +2209,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/ro.po
+++ b/po/ro.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Arthur Țițeică <arthur.titeica@gmail.com>, 2013-2015
@@ -200,9 +200,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Bine ai venit la  AUR! Te rog citește %sGhidul utilizatorului AUR%s și %sGhidul AUR TU%s pentru mai multe informații."
+msgstr "Bine ai venit la  MPR! Te rog citește %sGhidul utilizatorului MPR%s și %sGhidul MPR TU%s pentru mai multe informații."
 
 #: html/home.php
 #, php-format
@@ -225,7 +225,7 @@ msgstr "DECLARAȚIE DE NEASUMARE A RESPONSABILITĂȚII"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr ""
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr ""
@@ -293,13 +293,13 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
 msgstr ""
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
 msgstr ""
 
 #: html/home.php
@@ -309,9 +309,9 @@ msgstr "Discuție"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
 msgstr ""
 
 #: html/home.php
@@ -321,8 +321,8 @@ msgstr "Semnalare buguri"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -499,8 +499,8 @@ msgstr "Șterge pachet"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Folosește acest formular pentru a șterge pachetul de bază %s%s%s și următoarele pachete din AUR: "
+"from the MPR: "
+msgstr "Folosește acest formular pentru a șterge pachetul de bază %s%s%s și următoarele pachete din MPR: "
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1134,8 +1134,8 @@ msgstr "Cerere închisă cu succes."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Poți folosi acest formular pentru a șterge permanent contul AUR %s."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Poți folosi acest formular pentru a șterge permanent contul MPR %s."
 
 #: template/account_delete.php
 #, php-format
@@ -1295,7 +1295,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1344,7 +1344,7 @@ msgstr "Rescrie parola"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr ""
 
 #: template/account_edit_form.php
@@ -1377,7 +1377,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr "Adaugă comentariu"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2120,7 +2120,7 @@ msgid "Back"
 msgstr "Înapoi"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2132,19 +2132,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2161,7 +2161,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2171,7 +2171,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2181,7 +2181,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2196,7 +2196,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2211,7 +2211,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Evgeniy Alekseev <esalexeev@gmail.com>, 2014-2015
@@ -207,9 +207,9 @@ msgstr "Поиск пакетов, в которых я сопровождающ
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Добро пожаловать в AUR! Пожалуйста, ознакомьтесь с %sРуководством пользователя AUR%s и с %sРуководством доверенного пользователя AUR%s, чтобы узнать больше."
+msgstr "Добро пожаловать в MPR! Пожалуйста, ознакомьтесь с %sРуководством пользователя MPR%s и с %sРуководством доверенного пользователя MPR%s, чтобы узнать больше."
 
 #: html/home.php
 #, php-format
@@ -232,9 +232,9 @@ msgstr "Отказ от ответственности"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Пакеты в AUR содержат предоставленный пользователями контент. Любое использование предоставляемых файлов выполняйте на свой риск."
+msgstr "Пакеты в MPR содержат предоставленный пользователями контент. Любое использование предоставляемых файлов выполняйте на свой риск."
 
 #: html/home.php
 msgid "Learn more..."
@@ -271,10 +271,10 @@ msgstr "Запрос на удаление"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Запросить удаление пакета из AUR. Пожалуйста, не используйте это действие, если пакет не собирается и это может быть легко исправлено. Вместо этого, свяжитесь с сопровождающим и отправьте запрос на смену сопровождающего, если необходимо."
+msgstr "Запросить удаление пакета из MPR. Пожалуйста, не используйте это действие, если пакет не собирается и это может быть легко исправлено. Вместо этого, свяжитесь с сопровождающим и отправьте запрос на смену сопровождающего, если необходимо."
 
 #: html/home.php
 msgid "Merge Request"
@@ -300,14 +300,14 @@ msgstr "Загрузка пакетов"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "На текущий момент для загрузки пакетов в AUR используется Git через SSH. Смотри %sЗагрузка пакетов%s в ArchWiki для более подробной информации."
+msgstr "На текущий момент для загрузки пакетов в MPR используется Git через SSH. Смотри %sЗагрузка пакетов%s в ArchWiki для более подробной информации."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Следующие отпечатки ключей используются AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Следующие отпечатки ключей используются MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -316,10 +316,10 @@ msgstr "Обсуждение"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Общее обсуждение Пользовательского Репозитория ArchLinux (AUR) и структуры Доверенных Пользователей ведется в %saur-general%s. Для обсуждение разработки веб-интерфейса AUR используйте %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Общее обсуждение Пользовательского Репозитория ArchLinux (MPR) и структуры Доверенных Пользователей ведется в %saur-general%s. Для обсуждение разработки веб-интерфейса MPR используйте %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -328,11 +328,11 @@ msgstr "Отчет об ошибке"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Если вы нашли баг в интерфейсе AUR, пожалуйста, отправьте сообщение на %sбаг трекер%s. Используйте данный баг трекер %sтолько%s для сообщениях о багах в AUR. Если вы хотите сообщить о баге в пакете, свяжитесь с сопровождающим, или оставьте комментарий на соответствующей странице."
+msgstr "Если вы нашли баг в интерфейсе MPR, пожалуйста, отправьте сообщение на %sбаг трекер%s. Используйте данный баг трекер %sтолько%s для сообщениях о багах в MPR. Если вы хотите сообщить о баге в пакете, свяжитесь с сопровождающим, или оставьте комментарий на соответствующей странице."
 
 #: html/home.php
 msgid "Package Search"
@@ -506,8 +506,8 @@ msgstr "Удалить пакет"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Используйте эту форму, чтобы удалить группу пакетов %s%s%s из AUR:"
+"from the MPR: "
+msgstr "Используйте эту форму, чтобы удалить группу пакетов %s%s%s из MPR:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1141,8 +1141,8 @@ msgstr "Запрос закрыт успешно."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Вы можете использовать данную форму, чтобы удалить следующий аккаунт AUR: %s."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Вы можете использовать данную форму, чтобы удалить следующий аккаунт MPR: %s."
 
 #: template/account_delete.php
 #, php-format
@@ -1302,7 +1302,7 @@ msgstr "Скрыть email."
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1351,8 +1351,8 @@ msgstr "Введите пароль еще раз"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "Следующая информация необходима, только если вы хотите загружать пакеты в AUR."
+" the makedeb Package Repository."
+msgstr "Следующая информация необходима, только если вы хотите загружать пакеты в MPR."
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1384,7 +1384,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr "Добавить комментарий"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2132,7 +2132,7 @@ msgid "Back"
 msgstr "Назад"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2144,19 +2144,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2173,7 +2173,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2183,7 +2183,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2193,7 +2193,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2208,7 +2208,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2223,7 +2223,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # archetyp <archetyp@linuxmail.org>, 2013-2016
@@ -200,9 +200,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Vitajte v AUR! Prečítajte si prosím %sAUR smernicu pre užívateľov%s a %sAUR smernicu pre TU%s pre ďalšie informácie."
+msgstr "Vitajte v MPR! Prečítajte si prosím %sMPR smernicu pre užívateľov%s a %sMPR smernicu pre TU%s pre ďalšie informácie."
 
 #: html/home.php
 #, php-format
@@ -225,9 +225,9 @@ msgstr "UPOZORNENIE"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Balíčky v AUR sú výsledkom práce užívateľov. Akékoľvek použitie týchto súborov je na vlastnú zodpovednosť."
+msgstr "Balíčky v MPR sú výsledkom práce užívateľov. Akékoľvek použitie týchto súborov je na vlastnú zodpovednosť."
 
 #: html/home.php
 msgid "Learn more..."
@@ -264,10 +264,10 @@ msgstr "Žiadosť o vymazanie"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Žiadosť o odstránenie balíčka z AUR. Nepoužívajte prosím túto možnosť v prípade, že balíček je pokazený a možno ho ľahko opraviť. Namiesto toho radšej kontaktujte jeho správcu alebo v prípade nutnosti požiadajte o jeho osirenie."
+msgstr "Žiadosť o odstránenie balíčka z MPR. Nepoužívajte prosím túto možnosť v prípade, že balíček je pokazený a možno ho ľahko opraviť. Namiesto toho radšej kontaktujte jeho správcu alebo v prípade nutnosti požiadajte o jeho osirenie."
 
 #: html/home.php
 msgid "Merge Request"
@@ -293,14 +293,14 @@ msgstr "Podanie balíčkov"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Git cez SSH sa teraz používa na podanie balíčkov do AUR. Pre ďalšie informácie pozri tiež sekciu %sPodanie balíčkov%s na AUR stránke v ArchWiki."
+msgstr "Git cez SSH sa teraz používa na podanie balíčkov do MPR. Pre ďalšie informácie pozri tiež sekciu %sPodanie balíčkov%s na MPR stránke v ArchWiki."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Uvedené SSH fingerprints sa používajú pre AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Uvedené SSH fingerprints sa používajú pre MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -309,10 +309,10 @@ msgstr "Diskusia"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Všeobecná diskusia týkajúca sa Arch Užívateľského Repozitára (AUR) a štruktúry dôverovaných užívateľov (TU)  je na %saur-general%s.  Na diskusiu týkajúcu sa vývoja AUR webu použite %saur-dev%s mailing list."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Všeobecná diskusia týkajúca sa Arch Užívateľského Repozitára (MPR) a štruktúry dôverovaných užívateľov (TU)  je na %saur-general%s.  Na diskusiu týkajúcu sa vývoja MPR webu použite %saur-dev%s mailing list."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -321,11 +321,11 @@ msgstr "Ohlasovanie chýb"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Ak nájdete chybu vo webovom rozhradní AUR, pošlite prosím správu o chybe na náš %sbug tracker%s. Posielajte sem %slen%s chyby webového rozhrania AUR. Pre nahlásenie chýb balíčkov kontaktujte správcu balíčka alebo zanechate komentár na príslušnej stránke balíčka."
+msgstr "Ak nájdete chybu vo webovom rozhradní MPR, pošlite prosím správu o chybe na náš %sbug tracker%s. Posielajte sem %slen%s chyby webového rozhrania MPR. Pre nahlásenie chýb balíčkov kontaktujte správcu balíčka alebo zanechate komentár na príslušnej stránke balíčka."
 
 #: html/home.php
 msgid "Package Search"
@@ -499,8 +499,8 @@ msgstr "Vymaž balíček"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Použite tento formulár pre vymazanie základne balíčka %s%s%s a nasledovných balíčkov z AUR: "
+"from the MPR: "
+msgstr "Použite tento formulár pre vymazanie základne balíčka %s%s%s a nasledovných balíčkov z MPR: "
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1134,8 +1134,8 @@ msgstr "Žiadosť bola úspešne uzavretá."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Tento formulár môžete použiť na trvalé vymazanie AUR účtu %s."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Tento formulár môžete použiť na trvalé vymazanie MPR účtu %s."
 
 #: template/account_delete.php
 #, php-format
@@ -1295,7 +1295,7 @@ msgstr "Skryť emailovú adresu"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1344,8 +1344,8 @@ msgstr "Potvrďte heslo"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "Nasledujúca informácia je dôležitá iba v prípade, že chcete podať balíčky do AUR."
+" the makedeb Package Repository."
+msgstr "Nasledujúca informácia je dôležitá iba v prípade, že chcete podať balíčky do MPR."
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1377,7 +1377,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1598,7 +1598,7 @@ msgstr "Pridať komentár"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2125,7 +2125,7 @@ msgid "Back"
 msgstr "Späť"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2137,19 +2137,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2166,7 +2166,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2176,7 +2176,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2186,7 +2186,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2201,7 +2201,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2216,7 +2216,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Lukas Fleischer <transifex@cryptocrack.de>, 2011
@@ -200,9 +200,9 @@ msgstr "Pretraži pakete koje koodržavam"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Dobrodošli u AUR! Molimo pročitajte %sSmernice za korisnike AUR-a%s i %sSmernice za poverljive korinike%s za više informacija."
+msgstr "Dobrodošli u MPR! Molimo pročitajte %sSmernice za korisnike MPR-a%s i %sSmernice za poverljive korinike%s za više informacija."
 
 #: html/home.php
 #, php-format
@@ -225,9 +225,9 @@ msgstr "UPOZORENJE"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Paketi u AUR-u su sadržaj koji stvaraju korisnici. Upotrebljavate ih na sopstvenu odgovornost."
+msgstr "Paketi u MPR-u su sadržaj koji stvaraju korisnici. Upotrebljavate ih na sopstvenu odgovornost."
 
 #: html/home.php
 msgid "Learn more..."
@@ -264,7 +264,7 @@ msgstr "Zahtevi za brisanje"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr "zahtev za brisanje paketa iz Arčove Korisničke Riznice. Ne koristite ovo ako je paket polomljen i može se lako ispraviti. Umesto toga, kontaktirajte održavaoca paketa i podnesite zahtev za odricanje ukoliko je potreban."
@@ -293,14 +293,14 @@ msgstr "Prilaganje paketa"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Za prilaganje paketa u AUR sada se koristi Git preko SSH. Pogledajte sekciju %sPrilaganje paketa%s na stranici o AUR-u na Arčovom wikiju."
+msgstr "Za prilaganje paketa u MPR sada se koristi Git preko SSH. Pogledajte sekciju %sPrilaganje paketa%s na stranici o MPR-u na Arčovom wikiju."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Sledeći SSH otisci se koriste za AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Sledeći SSH otisci se koriste za MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -309,10 +309,10 @@ msgstr "Diskusija"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Opšta diskusija vezana za Arčovu Korisničku Riznicu (AUR) i strukturu Poverljivih korisnika se vodi na dopisnoj listi %saur-general%s.Za diskusiju o razvoju samog web sučelja AUR-a, pogedajte dopisnu listu %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Opšta diskusija vezana za Arčovu Korisničku Riznicu (MPR) i strukturu Poverljivih korisnika se vodi na dopisnoj listi %saur-general%s.Za diskusiju o razvoju samog web sučelja MPR-a, pogedajte dopisnu listu %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -321,11 +321,11 @@ msgstr "Prijavljivanje grešaka"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Ukoliko nađete grešku u web sučelju AUR-a. molimo da je prijavite na našem %sbubolovcu%s. Bubolovac koristite %sisključivo%s za prjavljivanje grešaka u samom AUR-u. Za prijavu grešaka u samim paketima kontaktirajte održavaoce paketa ili ostavite komentar na odgovarajućoj stranici paketa."
+msgstr "Ukoliko nađete grešku u web sučelju MPR-a. molimo da je prijavite na našem %sbubolovcu%s. Bubolovac koristite %sisključivo%s za prjavljivanje grešaka u samom MPR-u. Za prijavu grešaka u samim paketima kontaktirajte održavaoce paketa ili ostavite komentar na odgovarajućoj stranici paketa."
 
 #: html/home.php
 msgid "Package Search"
@@ -499,8 +499,8 @@ msgstr "Obriši paket"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Ovim formularom brišete osnovu paketa %s%s%s i sledeće pakete iz AUR-a:"
+"from the MPR: "
+msgstr "Ovim formularom brišete osnovu paketa %s%s%s i sledeće pakete iz MPR-a:"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1134,8 +1134,8 @@ msgstr "Zahtev je uspešno zatvoren."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Ovim možete trajno obrisati nalog %s iz AUR-a."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Ovim možete trajno obrisati nalog %s iz MPR-a."
 
 #: template/account_delete.php
 #, php-format
@@ -1295,7 +1295,7 @@ msgstr "Skrij adresu e-pošte"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1344,7 +1344,7 @@ msgstr "Ponovo unesite lozinku"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "Sledeće informacije su neophodne ako želite da prilažete pakete u Arčovu korisničku riznicu."
 
 #: template/account_edit_form.php
@@ -1377,7 +1377,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr "Dodaj komentar"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2120,7 +2120,7 @@ msgid "Back"
 msgstr "Nazad"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2132,19 +2132,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2161,7 +2161,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2171,7 +2171,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2181,7 +2181,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2196,7 +2196,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2211,7 +2211,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # tarakbumba <tarakbumba@gmail.com>, 2011,2013-2015
@@ -205,9 +205,9 @@ msgstr ""
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "AUR'a hoş geldiniz! Bilgi almak için lütfen %sAUR Kullanıcı Rehberi%s ve %sGK Rehberini%s okuyun."
+msgstr "MPR'a hoş geldiniz! Bilgi almak için lütfen %sMPR Kullanıcı Rehberi%s ve %sGK Rehberini%s okuyun."
 
 #: html/home.php
 #, php-format
@@ -230,9 +230,9 @@ msgstr "FERAGATNAME"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "AUR paketleri kullanıcılar tarafından üretilirler. Bu paketlerin herhangi bir risk taşıyabileceğini unutmayın."
+msgstr "MPR paketleri kullanıcılar tarafından üretilirler. Bu paketlerin herhangi bir risk taşıyabileceğini unutmayın."
 
 #: html/home.php
 msgid "Learn more..."
@@ -269,7 +269,7 @@ msgstr "Silme Talebi"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr "Bir paketin Arch Kullanıcı Deposundan kaldırılması talebidir. Lütfen bunu, bir paket çalışmıyor fakat kolayca düzeltilebiliyorsa kullanmayın. Bunun yerine, paket bakımcısı ile iletişim kurun ve mecbur kalınırsa paketin sahipsiz bırakılması talebinde bulunun."
@@ -298,14 +298,14 @@ msgstr "Paketleri göndermek"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Artık AUR' a paket göndermek için SSH üzerinden Git kullanılmaktadır. Daha fazla bilgi için Arch Kullanıcı Deposu ArchWiki sayfasındaki %sPaketleri Göndermek%s bölümüne bakın."
+msgstr "Artık MPR' a paket göndermek için SSH üzerinden Git kullanılmaktadır. Daha fazla bilgi için Arch Kullanıcı Deposu ArchWiki sayfasındaki %sPaketleri Göndermek%s bölümüne bakın."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "AUR için şu SSH parmak izleri kullanılmaktadır:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "MPR için şu SSH parmak izleri kullanılmaktadır:"
 
 #: html/home.php
 msgid "Discussion"
@@ -314,10 +314,10 @@ msgstr "Tartışma"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Arch Kullanıcı Deposu (AUR) ve Güvenilir Kullanıcı yapısı ile ilgili genel tartışmalar %saur-general%s üzerinde yapılır. AUR web arayüzü geliştirme süreci ilgili tartışmalar %saur-dev%s listesinde yapılmaktadır."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Arch Kullanıcı Deposu (MPR) ve Güvenilir Kullanıcı yapısı ile ilgili genel tartışmalar %saur-general%s üzerinde yapılır. MPR web arayüzü geliştirme süreci ilgili tartışmalar %saur-dev%s listesinde yapılmaktadır."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -326,8 +326,8 @@ msgstr "Hata Bildirimi"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
 msgstr ""
@@ -504,8 +504,8 @@ msgstr "Paketi Sil"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Bu formu paket temeli %s%s%s ve şu paketleri AUR üzerinden silmek için kullanın: "
+"from the MPR: "
+msgstr "Bu formu paket temeli %s%s%s ve şu paketleri MPR üzerinden silmek için kullanın: "
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1139,8 +1139,8 @@ msgstr "Talep başarıyla kapatıldı."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Bu formu kullanarak %s AUR hesabını temelli silebilirsiniz."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Bu formu kullanarak %s MPR hesabını temelli silebilirsiniz."
 
 #: template/account_delete.php
 #, php-format
@@ -1300,7 +1300,7 @@ msgstr "E-posta Adresini Gizle"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1349,7 +1349,7 @@ msgstr "Parolayı tekrar girin"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "Aşağıdaki bilgi sadece Arch Kullanıcı Deposu' na paket göndermek istiyorsanız gereklidir."
 
 #: template/account_edit_form.php
@@ -1382,7 +1382,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1601,7 +1601,7 @@ msgstr "Yorum Ekle"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2120,7 +2120,7 @@ msgid "Back"
 msgstr "Geri"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
+msgid "MPR Password Reset"
 msgstr ""
 
 #: scripts/notify.py
@@ -2132,19 +2132,19 @@ msgid ""
 msgstr ""
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr ""
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2161,7 +2161,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2171,7 +2171,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2181,7 +2181,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2196,7 +2196,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py
@@ -2211,7 +2211,7 @@ msgstr ""
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
 msgstr ""
 
 #: scripts/notify.py

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # Lukas Fleischer <transifex@cryptocrack.de>, 2011
@@ -203,9 +203,9 @@ msgstr "Пошук пакунків з сумісним супроводом"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "Раді вітати вас в «AUR» — у сховищі користувацьких пакунків. Розширена довідка надана в %sінструкції користувача AUR%s та %sінструкції довіреного користувача (TU) AUR%s."
+msgstr "Раді вітати вас в «MPR» — у сховищі користувацьких пакунків. Розширена довідка надана в %sінструкції користувача MPR%s та %sінструкції довіреного користувача (TU) MPR%s."
 
 #: html/home.php
 #, php-format
@@ -228,9 +228,9 @@ msgstr "ВІДМОВА ВІД ВІДПОВІДАЛЬНОСТІ"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "Пакунки у сховищі AUR - це пакунки, створені користувачами. Ви можете використовувати їх тільки на Ваш власний страх і ризик."
+msgstr "Пакунки у сховищі MPR - це пакунки, створені користувачами. Ви можете використовувати їх тільки на Ваш власний страх і ризик."
 
 #: html/home.php
 msgid "Learn more..."
@@ -267,10 +267,10 @@ msgstr "Запит щодо вилучення"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "Запит щодо вилучення пакунку зі сховища користувацьких пакунків AUR. Будь ласка, не використовуйте його, якщо пакунок містить проблеми, які можна легко виправити. Натомість зв’яжіться з супровідником пакунку та в разі необхідності зробіть запит покинути пакунок."
+msgstr "Запит щодо вилучення пакунку зі сховища користувацьких пакунків MPR. Будь ласка, не використовуйте його, якщо пакунок містить проблеми, які можна легко виправити. Натомість зв’яжіться з супровідником пакунку та в разі необхідності зробіть запит покинути пакунок."
 
 #: html/home.php
 msgid "Merge Request"
@@ -296,14 +296,14 @@ msgstr "Надсилання пакунків"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "Git через SSH тепер використовується для надсилання пакунків до AUR. Для деталей дивіться розділ %sНадсилання пакунків%s на сторінці ArchWiki про Сховище Користувацьких Пакунків AUR."
+msgstr "Git через SSH тепер використовується для надсилання пакунків до MPR. Для деталей дивіться розділ %sНадсилання пакунків%s на сторінці ArchWiki про Сховище Користувацьких Пакунків MPR."
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "Наступні відбитки ключів SSH використовуються в AUR:"
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "Наступні відбитки ключів SSH використовуються в MPR:"
 
 #: html/home.php
 msgid "Discussion"
@@ -312,10 +312,10 @@ msgstr "Обговорення"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "Загальне обговорення сховища користувацьких пакунків (AUR) та структури довірених користувачів відбувається в %saur-general%s. Для дискусій про розробку AUR використовуйте список розсилання %saur-dev%s."
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "Загальне обговорення сховища користувацьких пакунків (MPR) та структури довірених користувачів відбувається в %saur-general%s. Для дискусій про розробку MPR використовуйте список розсилання %saur-dev%s."
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -324,11 +324,11 @@ msgstr "Повідомлення про вади"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "Якщо Ви знайдете ваду у веб-інтерфейсі AUR, повідомте про це нас на нашому %sтрекері вад%s. Таким чином слід сповіщати %sлише%s про проблеми у веб-інтерфейсі AUR. Про вади пакунка зв’яжіться з його супровідником або залиште коментар на відповідній сторінці цього пакунка."
+msgstr "Якщо Ви знайдете ваду у веб-інтерфейсі MPR, повідомте про це нас на нашому %sтрекері вад%s. Таким чином слід сповіщати %sлише%s про проблеми у веб-інтерфейсі MPR. Про вади пакунка зв’яжіться з його супровідником або залиште коментар на відповідній сторінці цього пакунка."
 
 #: html/home.php
 msgid "Package Search"
@@ -502,8 +502,8 @@ msgstr "Вилучити пакунок"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "Використовуйте цю форму для вилучення бази пакунків %s%s%s і наступних пакунків з AUR. "
+"from the MPR: "
+msgstr "Використовуйте цю форму для вилучення бази пакунків %s%s%s і наступних пакунків з MPR. "
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1137,8 +1137,8 @@ msgstr "Запит успішно закритий."
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "Для безповоротного видалення облікового запису %s з AUR ви можете використати цю форму."
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "Для безповоротного видалення облікового запису %s з MPR ви можете використати цю форму."
 
 #: template/account_delete.php
 #, php-format
@@ -1298,7 +1298,7 @@ msgstr "Приховати адресу електронної пошти"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1347,8 +1347,8 @@ msgstr "Введіть пароль ще раз"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "Наступну інформацію потрібно, якщо Ви бажаєте надіслати пакунки до Сховища Користувацьких Пакунків AUR."
+" the makedeb Package Repository."
+msgstr "Наступну інформацію потрібно, якщо Ви бажаєте надіслати пакунки до Сховища Користувацьких Пакунків MPR."
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1380,7 +1380,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1601,7 +1601,7 @@ msgstr "Додати коментар"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2128,8 +2128,8 @@ msgid "Back"
 msgstr "Назад"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "Скидання паролю на AUR"
+msgid "MPR Password Reset"
+msgstr "Скидання паролю на MPR"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2140,20 +2140,20 @@ msgid ""
 msgstr "Запит скидання пароля для облікового запису {user} надіслано на пов’язану з ним адресу електронної пошти. Щоб скинути пароль, перейдіть за посиланням [1] нижче; щоб залишити все як є, проігноруйте це повідомлення."
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
-msgstr "Вітаємо Вас в Arch User Repository — сховищі користувацьких пакунків"
+msgid "Welcome to the makedeb Package Repository"
+msgstr "Вітаємо Вас в makedeb Package Repository — сховищі користувацьких пакунків"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
-msgstr "Вітаємо в AUR – сховищі користувацьких пакунків! Щоб встановити початковий пароль для вашого облікового запису натисніть на посилання [1] нижче. Якщо посилання не спрацьовує, скопіюйте його і вставте у ваш браузер."
+msgstr "Вітаємо в MPR – сховищі користувацьких пакунків! Щоб встановити початковий пароль для вашого облікового запису натисніть на посилання [1] нижче. Якщо посилання не спрацьовує, скопіюйте його і вставте у ваш браузер."
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "AUR коментар для {pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "MPR коментар для {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2169,8 +2169,8 @@ msgstr "Якщо Ви не бажаєте більше отримувати по
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "Оновлення пакунку AUR: {pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "Оновлення пакунку MPR: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2179,8 +2179,8 @@ msgstr "{user} [1] додав наступний коментар до {pkgbase}
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "Повідомлення AUR про застарілі для {pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "Повідомлення MPR про застарілі для {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2189,8 +2189,8 @@ msgstr "Цьому пакунку {pkgbase} [1] призначено мітку 
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "Повідомлення AUR про присвоєння для {pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "Повідомлення MPR про присвоєння для {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2204,8 +2204,8 @@ msgstr "Пакунок {pkgbase} [1] був покинутий користув�
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "Повідомлення про співсупровід AUR для {pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "Повідомлення про співсупровід MPR для {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2219,8 +2219,8 @@ msgstr "Вас видалили зі списку співсупровідник
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "Пакунок з AUR вилучено: {pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "Пакунок з MPR вилучено: {pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # leonfeng <chaofeng111@qq.com>, 2015-2016
@@ -205,9 +205,9 @@ msgstr "搜索共同维护的软件包"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "欢迎来到 AUR！想了解更多信息，请阅读 %sAUR 用户指南%s和 %sAUR 受信用户指南%s。"
+msgstr "欢迎来到 MPR！想了解更多信息，请阅读 %sMPR 用户指南%s和 %sMPR 受信用户指南%s。"
 
 #: html/home.php
 #, php-format
@@ -230,9 +230,9 @@ msgstr "免责声明"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "AUR 包为用户产生的内容。使用它们造成的后果自负。"
+msgstr "MPR 包为用户产生的内容。使用它们造成的后果自负。"
 
 #: html/home.php
 msgid "Learn more..."
@@ -269,10 +269,10 @@ msgstr "删除请求"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
-msgstr "请求软件包从 AUR 中移除。如果这个包虽然损坏了但是可以被轻易地修好，请不要进行此操作，您应该联系包的维护者或者有必要的情况下发送弃置请求。"
+msgstr "请求软件包从 MPR 中移除。如果这个包虽然损坏了但是可以被轻易地修好，请不要进行此操作，您应该联系包的维护者或者有必要的情况下发送弃置请求。"
 
 #: html/home.php
 msgid "Merge Request"
@@ -298,14 +298,14 @@ msgstr "提交软件包"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "现在请使用 Git over SSH 来向 AUR 提交软件包。如果想知道更多，请查看 Arch Wiki 上的 Arch User Repository (简体中文) 页面中 %s提交软件包%s 章节。"
+msgstr "现在请使用 Git over SSH 来向 MPR 提交软件包。如果想知道更多，请查看 Arch Wiki 上的 makedeb Package Repository (简体中文) 页面中 %s提交软件包%s 章节。"
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "AUR 使用以下 SSH 指纹："
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "MPR 使用以下 SSH 指纹："
 
 #: html/home.php
 msgid "Discussion"
@@ -314,10 +314,10 @@ msgstr "邮件列表"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "与 Arch 用户仓库（AUR）或者受信用户结构相关的一般讨论在 %saur-general%s 邮件列表。若是与 AUR web 页面开发相关的讨论，请使用 %saur-dev%s 邮件列表。"
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "与 Arch 用户仓库（MPR）或者受信用户结构相关的一般讨论在 %saur-general%s 邮件列表。若是与 MPR web 页面开发相关的讨论，请使用 %saur-dev%s 邮件列表。"
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -326,11 +326,11 @@ msgstr "Bug 报告"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "如果你在 AUR web 页面中发现了一个 Bug，请提交到我们的 %sBug 追踪系统%s。请%s仅仅%s使用追踪系统报告 AUR 自身的 Bug。如果想要报告打包方面的 Bug，请联系相应的包维护者，或者在相应的软件包页面中留下一条评论。"
+msgstr "如果你在 MPR web 页面中发现了一个 Bug，请提交到我们的 %sBug 追踪系统%s。请%s仅仅%s使用追踪系统报告 MPR 自身的 Bug。如果想要报告打包方面的 Bug，请联系相应的包维护者，或者在相应的软件包页面中留下一条评论。"
 
 #: html/home.php
 msgid "Package Search"
@@ -504,8 +504,8 @@ msgstr "删除软件包"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "使用这个表单将包基础 %s%s%s 和以下包从 AUR 中移除："
+"from the MPR: "
+msgstr "使用这个表单将包基础 %s%s%s 和以下包从 MPR 中移除："
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1139,8 +1139,8 @@ msgstr "请求关闭成功。"
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "你可以使用这个表单来彻底删除 AUR 帐号 %s。"
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "你可以使用这个表单来彻底删除 MPR 帐号 %s。"
 
 #: template/account_delete.php
 #, php-format
@@ -1300,7 +1300,7 @@ msgstr "隐藏 E-mail"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
 msgstr ""
@@ -1349,8 +1349,8 @@ msgstr "确认密码"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
-msgstr "仅仅当你想要向 AUR 提交软件包时才需要填写以下信息。"
+" the makedeb Package Repository."
+msgstr "仅仅当你想要向 MPR 提交软件包时才需要填写以下信息。"
 
 #: template/account_edit_form.php
 msgid "SSH Public Key"
@@ -1382,7 +1382,7 @@ msgstr ""
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
 msgstr ""
 
@@ -1600,7 +1600,7 @@ msgstr "添加评论"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
 msgstr ""
 
@@ -2115,8 +2115,8 @@ msgid "Back"
 msgstr "返回"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "重置 AUR 密码"
+msgid "MPR Password Reset"
+msgstr "重置 MPR 密码"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2127,20 +2127,20 @@ msgid ""
 msgstr "关联此邮件地址的用户 {user} 的重置密码请求已经提交。如果您想要重置密码，请点击以下链接 [1]，否则忽略此消息。"
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr "欢迎来到 Arch 用户软件仓库"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr "欢迎来到 Arch 用户软件仓库！想要为你的新账户设置初始密码，请点击下面的链接 [1]。如果链接不工作，请尝试复制它到你的浏览器中打开。"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "AUR 软件包评论：{pkgbase}"
+msgid "MPR Comment for {pkgbase}"
+msgstr "MPR 软件包评论：{pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2156,8 +2156,8 @@ msgstr "若您不愿再收到关于此软件包的通知，请到此软件包页
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "AUR 软件包更新：{pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "MPR 软件包更新：{pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2166,8 +2166,8 @@ msgstr "用户 {user} [1] 在软件包 {pkgbase} [2] 上传了新的提交："
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "AUR 软件包过期通知：{pkgbase}"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "MPR 软件包过期通知：{pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2176,8 +2176,8 @@ msgstr "您的软件包 {pkgbase} [1] 已被用户 {user} [2] 标记为过期：
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "AUR 软件包所有权通知：{pkgbase}"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "MPR 软件包所有权通知：{pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2191,8 +2191,8 @@ msgstr "软件包 {pkgbase} [1] 已被用户 {user} [2] 弃置。"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "AUR 软件包共同维护者通知：{pkgbase}"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "MPR 软件包共同维护者通知：{pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2206,8 +2206,8 @@ msgstr "您已被移出软件包 {pkgbase} [1] 的共同维护者列表。"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "AUR 软件包删除：{pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "MPR 软件包删除：{pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the AURWEB package.
+# This file is distributed under the same license as the MPRWEB package.
 # 
 # Translators:
 # byStarTW (pan93412) <pan93412@gmail.com>, 2018
@@ -200,9 +200,9 @@ msgstr "搜尋我共同維護的套件"
 #: html/home.php
 #, php-format
 msgid ""
-"Welcome to the AUR! Please read the %sAUR User Guidelines%s and %sAUR TU "
+"Welcome to the MPR! Please read the %sMPR User Guidelines%s and %sMPR TU "
 "Guidelines%s for more information."
-msgstr "歡迎來到 AUR！請閱讀 %sAUR 使用者指導方針%s 和 %sAUR 受信使用者指導方針%s 以獲取更多的詳細資訊。"
+msgstr "歡迎來到 MPR！請閱讀 %sMPR 使用者指導方針%s 和 %sMPR 受信使用者指導方針%s 以獲取更多的詳細資訊。"
 
 #: html/home.php
 #, php-format
@@ -225,9 +225,9 @@ msgstr "免責聲明"
 
 #: html/home.php template/footer.php
 msgid ""
-"AUR packages are user produced content. Any use of the provided files is at "
+"MPR packages are user produced content. Any use of the provided files is at "
 "your own risk."
-msgstr "AUR 上的檔案是使用者產生的內容。任何使用檔案造成的風險由您自行承擔。"
+msgstr "MPR 上的檔案是使用者產生的內容。任何使用檔案造成的風險由您自行承擔。"
 
 #: html/home.php
 msgid "Learn more..."
@@ -264,7 +264,7 @@ msgstr "刪除請求"
 
 #: html/home.php
 msgid ""
-"Request a package to be removed from the Arch User Repository. Please do not"
+"Request a package to be removed from the makedeb Package Repository. Please do not"
 " use this if a package is broken and can be fixed easily. Instead, contact "
 "the package maintainer and file orphan request if necessary."
 msgstr "請求套件從 Arch 使用者套件庫中移除。如果套件損毀但可以很容易的被修復，請不要使用這個請求。您應該聯絡套件維護者，並在必要時提出棄置請求。"
@@ -293,14 +293,14 @@ msgstr "遞交套件"
 #: html/home.php
 #, php-format
 msgid ""
-"Git over SSH is now used to submit packages to the AUR. See the %sSubmitting"
-" packages%s section of the Arch User Repository ArchWiki page for more "
+"Git over SSH is now used to submit packages to the MPR. See the %sSubmitting"
+" packages%s section of the makedeb Package Repository ArchWiki page for more "
 "details."
-msgstr "現在遞交套件到 AUR 上的方法是透過 SSH 的 Git。參見 ArchWiki 上的 Arch User Repository 頁面之 %s遞交套件%s 章節以取得更多資訊。"
+msgstr "現在遞交套件到 MPR 上的方法是透過 SSH 的 Git。參見 ArchWiki 上的 makedeb Package Repository 頁面之 %s遞交套件%s 章節以取得更多資訊。"
 
 #: html/home.php
-msgid "The following SSH fingerprints are used for the AUR:"
-msgstr "AUR 使用下列 SSH 指紋："
+msgid "The following SSH fingerprints are used for the MPR:"
+msgstr "MPR 使用下列 SSH 指紋："
 
 #: html/home.php
 msgid "Discussion"
@@ -309,10 +309,10 @@ msgstr "討論"
 #: html/home.php
 #, php-format
 msgid ""
-"General discussion regarding the Arch User Repository (AUR) and Trusted User"
+"General discussion regarding the makedeb Package Repository (MPR) and Trusted User"
 " structure takes place on %saur-general%s. For discussion relating to the "
-"development of the AUR web interface, use the %saur-dev%s mailing list."
-msgstr "與 Arch 使用者套件庫(AUR)及受信使用者結構相關的一般性討論請見 %saur-general%s 。討論關於 AUR 網頁介面的開發，請使用 %saur-dev%s 郵件列表。"
+"development of the MPR web interface, use the %saur-dev%s mailing list."
+msgstr "與 Arch 使用者套件庫(MPR)及受信使用者結構相關的一般性討論請見 %saur-general%s 。討論關於 MPR 網頁介面的開發，請使用 %saur-dev%s 郵件列表。"
 
 #: html/home.php
 msgid "Bug Reporting"
@@ -321,11 +321,11 @@ msgstr "臭蟲回報"
 #: html/home.php
 #, php-format
 msgid ""
-"If you find a bug in the AUR web interface, please fill out a bug report on "
-"our %sbug tracker%s. Use the tracker to report bugs in the AUR web interface"
+"If you find a bug in the MPR web interface, please fill out a bug report on "
+"our %sbug tracker%s. Use the tracker to report bugs in the MPR web interface"
 " %sonly%s. To report packaging bugs contact the package maintainer or leave "
 "a comment on the appropriate package page."
-msgstr "如果您在 AUR 網頁介面中發現了臭蟲，請在我們的 %s臭蟲追蹤系統%s 中回報。請%s只%s回報 AUR 網頁介面本身的臭蟲。要回報打包臭蟲，請連絡套件的維護者或是在對應的套件頁面中留下評論。"
+msgstr "如果您在 MPR 網頁介面中發現了臭蟲，請在我們的 %s臭蟲追蹤系統%s 中回報。請%s只%s回報 MPR 網頁介面本身的臭蟲。要回報打包臭蟲，請連絡套件的維護者或是在對應的套件頁面中留下評論。"
 
 #: html/home.php
 msgid "Package Search"
@@ -499,8 +499,8 @@ msgstr "刪除套件"
 #, php-format
 msgid ""
 "Use this form to delete the package base %s%s%s and the following packages "
-"from the AUR: "
-msgstr "使用這個表單以從 AUR 刪除套件基礎 %s%s%s 以及以下的套件。"
+"from the MPR: "
+msgstr "使用這個表單以從 MPR 刪除套件基礎 %s%s%s 以及以下的套件。"
 
 #: html/pkgdel.php
 msgid "Deletion of a package is permanent. "
@@ -1134,8 +1134,8 @@ msgstr "請求關閉成功。"
 
 #: template/account_delete.php
 #, php-format
-msgid "You can use this form to permanently delete the AUR account %s."
-msgstr "您可以使用這個表單來永久刪除 AUR 帳號 %s 。"
+msgid "You can use this form to permanently delete the MPR account %s."
+msgstr "您可以使用這個表單來永久刪除 MPR 帳號 %s 。"
 
 #: template/account_delete.php
 #, php-format
@@ -1295,10 +1295,10 @@ msgstr "隱藏電子郵件地址"
 
 #: template/account_edit_form.php
 msgid ""
-"If you do not hide your email address, it is visible to all registered AUR "
+"If you do not hide your email address, it is visible to all registered MPR "
 "users. If you hide your email address, it is visible to members of the Arch "
 "Linux staff only."
-msgstr "如果您不隱藏您的電子郵件地址，它就是對所有已註冊的 AUR 使用者可見。如果您隱藏您的電子郵件地址，它就只對 Arch Linux 工作人員可見。"
+msgstr "如果您不隱藏您的電子郵件地址，它就是對所有已註冊的 MPR 使用者可見。如果您隱藏您的電子郵件地址，它就只對 Arch Linux 工作人員可見。"
 
 #: template/account_edit_form.php
 msgid "Backup Email Address"
@@ -1344,7 +1344,7 @@ msgstr "重新輸入密碼"
 #: template/account_edit_form.php
 msgid ""
 "The following information is only required if you want to submit packages to"
-" the Arch User Repository."
+" the makedeb Package Repository."
 msgstr "以下的資訊僅在您想要遞交套件到 Arch 使用者套件庫時是必須的。"
 
 #: template/account_edit_form.php
@@ -1377,9 +1377,9 @@ msgstr "您目前的密碼"
 
 #: template/account_edit_form.php
 msgid ""
-"To protect the AUR against automated account creation, we kindly ask you to "
+"To protect the MPR against automated account creation, we kindly ask you to "
 "provide the output of the following command:"
-msgstr "為了保護 AUR 不受自動建立帳號的侵擾，我們請您提供以下指令的輸出："
+msgstr "為了保護 MPR 不受自動建立帳號的侵擾，我們請您提供以下指令的輸出："
 
 #: template/account_edit_form.php
 msgid "Answer"
@@ -1595,9 +1595,9 @@ msgstr "新增評論"
 
 #: template/pkg_comment_form.php
 msgid ""
-"Git commit identifiers referencing commits in the AUR package repository and"
+"Git commit identifiers referencing commits in the MPR package repository and"
 " URLs are converted to links automatically."
-msgstr "引用 AUR 軟體庫的 Git 遞交識別符，URL 會自動轉換為連結。"
+msgstr "引用 MPR 軟體庫的 Git 遞交識別符，URL 會自動轉換為連結。"
 
 #: template/pkg_comment_form.php
 #, php-format
@@ -2110,8 +2110,8 @@ msgid "Back"
 msgstr "返回"
 
 #: scripts/notify.py
-msgid "AUR Password Reset"
-msgstr "AUR 密碼重設"
+msgid "MPR Password Reset"
+msgstr "MPR 密碼重設"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2122,20 +2122,20 @@ msgid ""
 msgstr "有一個關於您帳號 {user} 對應到電子信箱的密碼重設請求。若您想要重設您的密碼，請前往以下的網址 [1]，否則忽略這訊息就沒事了。"
 
 #: scripts/notify.py
-msgid "Welcome to the Arch User Repository"
+msgid "Welcome to the makedeb Package Repository"
 msgstr "歡迎來到 Arch 使用者軟體庫"
 
 #: scripts/notify.py
 msgid ""
-"Welcome to the Arch User Repository! In order to set an initial password for"
+"Welcome to the makedeb Package Repository! In order to set an initial password for"
 " your new account, please click the link [1] below. If the link does not "
 "work, try copying and pasting it into your browser."
 msgstr "歡迎來到 Arch 使用者軟體庫！為了要設定您新帳號的初始密碼，請點擊以下的連結 [1]。若連結沒辦法點擊，請嘗試複製並貼上連結到您的瀏覽器中。 "
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Comment for {pkgbase}"
-msgstr "{pkgbase} 的 AUR 評論"
+msgid "MPR Comment for {pkgbase}"
+msgstr "{pkgbase} 的 MPR 評論"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2151,8 +2151,8 @@ msgstr "若您不再想收到此軟體包的通知，請前往軟體包頁面 [2
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package Update: {pkgbase}"
-msgstr "AUR 軟體包更新：{pkgbase}"
+msgid "MPR Package Update: {pkgbase}"
+msgstr "MPR 軟體包更新：{pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2161,8 +2161,8 @@ msgstr "{user} [1] 推送了新的提交到 {pkgbase} [2]。"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Out-of-date Notification for {pkgbase}"
-msgstr "{pkgbase} 的 AUR 過期通知"
+msgid "MPR Out-of-date Notification for {pkgbase}"
+msgstr "{pkgbase} 的 MPR 過期通知"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2171,8 +2171,8 @@ msgstr "您的軟體包 {pkgbase} [1] 已經被 {user} [2] 使用者標記為過
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Ownership Notification for {pkgbase}"
-msgstr "{pkgbase} 的 AUR 所有權通知"
+msgid "MPR Ownership Notification for {pkgbase}"
+msgstr "{pkgbase} 的 MPR 所有權通知"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2186,8 +2186,8 @@ msgstr "軟體包 {pkgbase} [1] 已經被 {user} [2] 使用者拋棄。"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Co-Maintainer Notification for {pkgbase}"
-msgstr "{pkgbase} 的 AUR 共同維護者通知"
+msgid "MPR Co-Maintainer Notification for {pkgbase}"
+msgstr "{pkgbase} 的 MPR 共同維護者通知"
 
 #: scripts/notify.py
 #, python-brace-format
@@ -2201,8 +2201,8 @@ msgstr "您已經從 {pkgbase} [1] 的共同維護者列表中移除了。"
 
 #: scripts/notify.py
 #, python-brace-format
-msgid "AUR Package deleted: {pkgbase}"
-msgstr "已刪除 AUR 軟體包：{pkgbase}"
+msgid "MPR Package deleted: {pkgbase}"
+msgstr "已刪除 MPR 軟體包：{pkgbase}"
 
 #: scripts/notify.py
 #, python-brace-format

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@ ifdef PROVE
 sh:
 	prove .
 else
-sh: $(T)
+sh: t2500-notify.t
 endif
 
 coverage:
@@ -26,6 +26,6 @@ clean:
 	rm -f ../.coverage
 
 $(T):
-	@echo "*** $@ ***"; $(SHELL) $@
+	@echo "*** $@ ***"; $(SHELL) $@ -v
 
 .PHONY: check coverage $(FOREIGN_TARGETS) clean $(T)

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@ ifdef PROVE
 sh:
 	prove .
 else
-sh: t2500-notify.t
+sh: $(T)
 endif
 
 coverage:

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -31,19 +31,19 @@ name = aur.db
 
 [options]
 aurwebdir = $TOPLEVEL
-aur_location = https://aur.archlinux.org
-aur_request_ml = aur-requests@lists.archlinux.org
+aur_location = https://mpr.hunterwittenborn.com
+aur_request_ml = mpr-requests@lists.hunterwittenborn.com
 enable-maintenance = 0
 maintenance-exceptions = 127.0.0.1
-commit_uri = https://aur.archlinux.org/cgit/aur.git/log/?h=%s&id=%s
+commit_uri = https://mpr.hunterwittenborn.com/cgit/aur.git/log/?h=%s&id=%s
 localedir = $TOPLEVEL/web/locale/
 snapshot_uri = /cgit/aur.git/snapshot/%s.tar.gz
 
 [notifications]
 notify-cmd = $NOTIFY
 sendmail = ./sendmail.sh
-sender = notify@aur.archlinux.org
-reply-to = noreply@aur.archlinux.org
+sender = mpr@hunterwittenborn.com
+reply-to = mpr@hunterwittenborn.com
 
 [auth]
 valid-keytypes = ssh-rsa ssh-dss ecdsa-sha2-nistp256 ecdsa-sha2-nistp384 ecdsa-sha2-nistp521 ssh-ed25519
@@ -56,7 +56,7 @@ repo-path = ./aur.git/
 repo-regex = [a-z0-9][a-z0-9.+_-]*$
 git-shell-cmd = ./git-shell.sh
 git-update-cmd = ./update.sh
-ssh-cmdline = ssh aur@aur.archlinux.org
+ssh-cmdline = ssh mpr@mpr.hunterwittenborn.com
 
 [update]
 max-blob-size = 256000

--- a/test/t2500-notify.t
+++ b/test/t2500-notify.t
@@ -20,11 +20,11 @@ test_expect_success 'Test out-of-date notifications.' '
 	>sendmail.out &&
 	cover "$NOTIFY" flag 1 1001 &&
 	cat <<-EOD >expected &&
-	Subject: AUR Out-of-date Notification for foobar
+	Subject: MPR Out-of-date Notification for foobar
 	To: tu@localhost
-	Subject: AUR Out-of-date Notification for foobar
+	Subject: MPR Out-of-date Notification for foobar
 	To: user2@localhost
-	Subject: AUR Out-of-date Notification for foobar
+	Subject: MPR Out-of-date Notification for foobar
 	To: user@localhost
 	EOD
 	grep "^\(Subject\|To\)" sendmail.out >sendmail.parts &&
@@ -42,7 +42,7 @@ test_expect_success 'Test subject and body of reset key notifications.' '
 	cover "$NOTIFY" send-resetkey 1 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Password Reset
+	Subject: MPR Password Reset
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -52,7 +52,7 @@ test_expect_success 'Test subject and body of reset key notifications.' '
 	with your email address. If you wish to reset your password follow the
 	link [1] below, otherwise ignore this message and nothing will happen.
 
-	[1] https://aur.archlinux.org/passreset/?resetkey=12345678901234567890123456789012
+	[1] https://mpr.hunterwittenborn.com/passreset/?resetkey=12345678901234567890123456789012
 	EOD
 	test_cmp actual expected
 '
@@ -65,17 +65,17 @@ test_expect_success 'Test subject and body of welcome notifications.' '
 	cover "$NOTIFY" welcome 1 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: Welcome to the Arch User Repository
+	Subject: Welcome to the makedeb Package Repository
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
 	echo >>actual &&
 	cat <<-EOD >expected &&
-	Welcome to the Arch User Repository! In order to set an initial
+	Welcome to the makedeb Package Repository! In order to set an initial
 	password for your new account, please click the link [1] below. If the
 	link does not work, try copying and pasting it into your browser.
 
-	[1] https://aur.archlinux.org/passreset/?resetkey=12345678901234567890123456789012
+	[1] https://mpr.hunterwittenborn.com/passreset/?resetkey=12345678901234567890123456789012
 	EOD
 	test_cmp actual expected
 '
@@ -91,7 +91,7 @@ test_expect_success 'Test subject and body of comment notifications.' '
 	cover "$NOTIFY" comment 1 1001 2001 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Comment for foobar
+	Subject: MPR Comment for foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -105,8 +105,8 @@ test_expect_success 'Test subject and body of comment notifications.' '
 	If you no longer wish to receive notifications about this package,
 	please go to the package page [2] and select "Disable notifications".
 	
-	[1] https://aur.archlinux.org/account/user/
-	[2] https://aur.archlinux.org/pkgbase/foobar/
+	[1] https://mpr.hunterwittenborn.com/account/user/
+	[2] https://mpr.hunterwittenborn.com/pkgbase/foobar/
 	EOD
 	test_cmp actual expected
 '
@@ -119,7 +119,7 @@ test_expect_success 'Test subject and body of update notifications.' '
 	cover "$NOTIFY" update 1 1001 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Package Update: foobar
+	Subject: MPR Package Update: foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -131,8 +131,8 @@ test_expect_success 'Test subject and body of update notifications.' '
 	If you no longer wish to receive notifications about this package,
 	please go to the package page [2] and select "Disable notifications".
 
-	[1] https://aur.archlinux.org/account/user/
-	[2] https://aur.archlinux.org/pkgbase/foobar/
+	[1] https://mpr.hunterwittenborn.com/account/user/
+	[2] https://mpr.hunterwittenborn.com/pkgbase/foobar/
 	EOD
 	test_cmp actual expected
 '
@@ -142,7 +142,7 @@ test_expect_success 'Test subject and body of out-of-date notifications.' '
 	cover "$NOTIFY" flag 1 1001 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Out-of-date Notification for foobar
+	Subject: MPR Out-of-date Notification for foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -152,8 +152,8 @@ test_expect_success 'Test subject and body of out-of-date notifications.' '
 
 	This is a test OOD comment.
 
-	[1] https://aur.archlinux.org/pkgbase/foobar/
-	[2] https://aur.archlinux.org/account/user/
+	[1] https://mpr.hunterwittenborn.com/pkgbase/foobar/
+	[2] https://mpr.hunterwittenborn.com/account/user/
 	EOD
 	test_cmp actual expected
 '
@@ -163,7 +163,7 @@ test_expect_success 'Test subject and body of adopt notifications.' '
 	cover "$NOTIFY" adopt 1 1001 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Ownership Notification for foobar
+	Subject: MPR Ownership Notification for foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -171,8 +171,8 @@ test_expect_success 'Test subject and body of adopt notifications.' '
 	cat <<-EOD >expected &&
 	The package foobar [1] was adopted by user [2].
 
-	[1] https://aur.archlinux.org/pkgbase/foobar/
-	[2] https://aur.archlinux.org/account/user/
+	[1] https://mpr.hunterwittenborn.com/pkgbase/foobar/
+	[2] https://mpr.hunterwittenborn.com/account/user/
 	EOD
 	test_cmp actual expected
 '
@@ -182,7 +182,7 @@ test_expect_success 'Test subject and body of disown notifications.' '
 	cover "$NOTIFY" disown 1 1001 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Ownership Notification for foobar
+	Subject: MPR Ownership Notification for foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -190,8 +190,8 @@ test_expect_success 'Test subject and body of disown notifications.' '
 	cat <<-EOD >expected &&
 	The package foobar [1] was disowned by user [2].
 
-	[1] https://aur.archlinux.org/pkgbase/foobar/
-	[2] https://aur.archlinux.org/account/user/
+	[1] https://mpr.hunterwittenborn.com/pkgbase/foobar/
+	[2] https://mpr.hunterwittenborn.com/account/user/
 	EOD
 	test_cmp actual expected
 '
@@ -201,7 +201,7 @@ test_expect_success 'Test subject and body of co-maintainer addition notificatio
 	cover "$NOTIFY" comaintainer-add 1 1001 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Co-Maintainer Notification for foobar
+	Subject: MPR Co-Maintainer Notification for foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -209,7 +209,7 @@ test_expect_success 'Test subject and body of co-maintainer addition notificatio
 	cat <<-EOD >expected &&
 	You were added to the co-maintainer list of foobar [1].
 
-	[1] https://aur.archlinux.org/pkgbase/foobar/
+	[1] https://mpr.hunterwittenborn.com/pkgbase/foobar/
 	EOD
 	test_cmp actual expected
 '
@@ -219,7 +219,7 @@ test_expect_success 'Test subject and body of co-maintainer removal notification
 	cover "$NOTIFY" comaintainer-remove 1 1001 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Co-Maintainer Notification for foobar
+	Subject: MPR Co-Maintainer Notification for foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -227,7 +227,7 @@ test_expect_success 'Test subject and body of co-maintainer removal notification
 	cat <<-EOD >expected &&
 	You were removed from the co-maintainer list of foobar [1].
 
-	[1] https://aur.archlinux.org/pkgbase/foobar/
+	[1] https://mpr.hunterwittenborn.com/pkgbase/foobar/
 	EOD
 	test_cmp actual expected
 '
@@ -237,7 +237,7 @@ test_expect_success 'Test subject and body of delete notifications.' '
 	cover "$NOTIFY" delete 1 1001 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Package deleted: foobar
+	Subject: MPR Package deleted: foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -247,8 +247,8 @@ test_expect_success 'Test subject and body of delete notifications.' '
 
 	You will no longer receive notifications about this package.
 
-	[1] https://aur.archlinux.org/account/user/
-	[2] https://aur.archlinux.org/pkgbase/foobar/
+	[1] https://mpr.hunterwittenborn.com/account/user/
+	[2] https://mpr.hunterwittenborn.com/pkgbase/foobar/
 	EOD
 	test_cmp actual expected
 '
@@ -258,7 +258,7 @@ test_expect_success 'Test subject and body of merge notifications.' '
 	cover "$NOTIFY" delete 1 1001 1002 &&
 	grep ^Subject: sendmail.out >actual &&
 	cat <<-EOD >expected &&
-	Subject: AUR Package deleted: foobar
+	Subject: MPR Package deleted: foobar
 	EOD
 	test_cmp actual expected &&
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
@@ -270,9 +270,9 @@ test_expect_success 'Test subject and body of merge notifications.' '
 	If you no longer wish receive notifications about the new package,
 	please go to [3] and click "Disable notifications".
 
-	[1] https://aur.archlinux.org/account/user/
-	[2] https://aur.archlinux.org/pkgbase/foobar/
-	[3] https://aur.archlinux.org/pkgbase/foobar2/
+	[1] https://mpr.hunterwittenborn.com/account/user/
+	[2] https://mpr.hunterwittenborn.com/pkgbase/foobar/
+	[3] https://mpr.hunterwittenborn.com/pkgbase/foobar2/
 	EOD
 	test_cmp actual expected
 '
@@ -301,8 +301,8 @@ test_expect_success 'Test Cc, subject and body of request open notifications.' '
 
 	This is a request test comment.
 
-	[1] https://aur.archlinux.org/account/user/
-	[2] https://aur.archlinux.org/pkgbase/foobar/
+	[1] https://mpr.hunterwittenborn.com/account/user/
+	[2] https://mpr.hunterwittenborn.com/pkgbase/foobar/
 	EOD
 	test_cmp actual expected
 '
@@ -322,9 +322,9 @@ test_expect_success 'Test subject and body of request open notifications for mer
 
 	This is a request test comment.
 
-	[1] https://aur.archlinux.org/account/user/
-	[2] https://aur.archlinux.org/pkgbase/foobar/
-	[3] https://aur.archlinux.org/pkgbase/foobar2/
+	[1] https://mpr.hunterwittenborn.com/account/user/
+	[2] https://mpr.hunterwittenborn.com/pkgbase/foobar/
+	[3] https://mpr.hunterwittenborn.com/pkgbase/foobar2/
 	EOD
 	test_cmp actual expected
 '
@@ -347,7 +347,7 @@ test_expect_success 'Test Cc, subject and body of request close notifications.' 
 	cat <<-EOD >expected &&
 	Request #3001 has been accepted by user [1].
 
-	[1] https://aur.archlinux.org/account/user/
+	[1] https://mpr.hunterwittenborn.com/account/user/
 	EOD
 	test_cmp actual expected
 '
@@ -363,7 +363,7 @@ test_expect_success 'Test subject and body of request close notifications (auto-
 	sed -n "/^\$/,\$p" sendmail.out | base64 -d >actual &&
 	echo >>actual &&
 	cat <<-EOD >expected &&
-	Request #3001 has been accepted automatically by the Arch User
+	Request #3001 has been accepted automatically by the makedeb Package
 	Repository package request system.
 	EOD
 	test_cmp actual expected
@@ -404,7 +404,7 @@ test_expect_success 'Test subject and body of request close notifications with c
 
 	This is a test closure comment.
 
-	[1] https://aur.archlinux.org/account/user/
+	[1] https://mpr.hunterwittenborn.com/account/user/
 	EOD
 	test_cmp actual expected
 '
@@ -423,7 +423,7 @@ test_expect_success 'Test subject and body of TU vote reminders.' '
 	Please remember to cast your vote on proposal 1 [1]. The voting period
 	ends in less than 48 hours.
 
-	[1] https://aur.archlinux.org/tu/?id=1
+	[1] https://mpr.hunterwittenborn.com/tu/?id=1
 	EOD
 	test_cmp actual expected
 '

--- a/test/t2600-rendercomment.t
+++ b/test/t2600-rendercomment.t
@@ -91,9 +91,9 @@ test_expect_success 'Test Git commit linkification.' '
 	EOD
 	cover "$RENDERCOMMENT" 5 &&
 	cat <<-EOD >expected &&
-		<p><a href="https://aur.archlinux.org/cgit/aur.git/log/?h=foobar&amp;id=${oid:0:12}">${oid:0:12}</a>
-		<a href="https://aur.archlinux.org/cgit/aur.git/log/?h=foobar&amp;id=${oid:0:7}">${oid:0:7}</a>
-		x.<a href="https://aur.archlinux.org/cgit/aur.git/log/?h=foobar&amp;id=${oid:0:12}">${oid:0:12}</a>.x
+		<p><a href="https://mpr.hunterwittenborn.com/cgit/aur.git/log/?h=foobar&amp;id=${oid:0:12}">${oid:0:12}</a>
+		<a href="https://mpr.hunterwittenborn.com/cgit/aur.git/log/?h=foobar&amp;id=${oid:0:7}">${oid:0:7}</a>
+		x.<a href="https://mpr.hunterwittenborn.com/cgit/aur.git/log/?h=foobar&amp;id=${oid:0:12}">${oid:0:12}</a>.x
 		${oid}x
 		0123456789abcdef
 		<code>$oid</code>

--- a/test/test_asgi.py
+++ b/test/test_asgi.py
@@ -1,5 +1,4 @@
 import http
-import os
 
 from unittest import mock
 

--- a/test/test_asgi.py
+++ b/test/test_asgi.py
@@ -30,15 +30,6 @@ async def test_asgi_startup_session_secret_exception(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_asgi_startup_exception(monkeypatch):
-    with mock.patch.dict(os.environ, {"AUR_CONFIG": "conf/config.defaults"}):
-        aurweb.config.rehash()
-        with pytest.raises(Exception):
-            await aurweb.asgi.app_startup()
-    aurweb.config.rehash()
-
-
-@pytest.mark.asyncio
 async def test_asgi_http_exception_handler():
     exc = HTTPException(status_code=422, detail="EXCEPTION!")
     phrase = http.HTTPStatus(exc.status_code).phrase


### PR DESCRIPTION
- Updated translations to work with MPR branding
- Added '__pycache__' to '.dockerignore'.
- Updated CI to only publish when running from the 'mprweb' branch.
- Pytests in CI now use 'docker/scripts/run-pytests.sh'.
- Fixed typo for 'trash_directory' in '.gitignore'.
- Removed AUR references in 'aurweb/scripts/notify.py' and 'conf/config.defaults'.